### PR TITLE
Enhance EV check with degree of success notes, target, and diverse lore

### DIFF
--- a/module/exploit-vulnerability.js
+++ b/module/exploit-vulnerability.js
@@ -64,11 +64,6 @@ export async function createEffectOnActor(sa, t, effect) {
 }
 
 export async function exploitVuln() {
-	const DCByLevel = [13, 14, 15, 16, 18, 19, 20, 22, 23, 24, 26, 27, 28, 30, 31, 32, 34, 35, 36, 38, 39, 40, 42, 44, 46, 48, 50];
-	const skillName = "Esoteric Lore";
-	const skillSlug = skillName.slugify();
-	const actionName = "Recall Knowledge";
-	
 	//grab the selected token and the targeted token
 	const a = canvas.tokens.controlled;
 	let ts = Array.from(game.user.targets);
@@ -88,54 +83,74 @@ export async function exploitVuln() {
 		return ui.notifications.warn(`${a[0].actor.name} does not have the ability to Exploit Vulnerability`);
 	}
 	
+	// From https://gist.github.com/stwlam/01c2506e93c298b01ad83c182b245144 by somebody, Supe, and stwlam 
+	const skill = sa.system.skills["esoteric-lore"];
+	if (!skill) {
+		return ui.notifications.warn(`${sa.name} does not have the Esoteric Lore skill`);
+	}
+	const dc = {
+		"-1": 13,
+		...Object.fromEntries(Object.entries([14, 15, 16, 18, 19, 20, 22, 23, 24, 26, 27, 28, 30, 31, 32, 34, 35, 36, 38, 39, 40, 42, 44, 46, 48, 50])),
+	}[t.actor.level];
+	if (!dc) {
+		return ui.notifications.warn("No matching DC for target");
+	}
+
 	//deletes Exploit Vulnerability effect if it already exists on the actor
 	await deleteEVEffect(canvas.tokens.placeables, sa);
+		const rollOptions = sa.getRollOptions(["skill-check", skill.slug]);
+
+	const outcomes = {
+		criticalSuccess: "You remember the creature's weaknesses, and as you empower your esoterica, you have a flash of insight that grants even more knowledge about the creature. You learn all of the creature's resistances, weaknesses, and immunities, including the amounts of the resistances and weaknesses and any unusual weaknesses or vulnerabilities, such as what spells will pass through a golem's antimagic. You can exploit either the creature's mortal weakness or personal antithesis (see below). Your unarmed and weapon Strikes against the creature also become magical if they weren't already.",
+		success: "You recall an important fact about the creature, learning its highest weakness (or one of its highest weaknesses, if it has multiple with the same value) but not its other weaknesses, resistances, or immunities. You can exploit either the creature's mortal weakness or personal antithesis. Your unarmed and weapon Strikes against the creature also become magical if they weren't already.",
+		failure: "Failing to recall a salient weakness about the creature, you instead attempt to exploit a more personal vulnerability. You can exploit only the creature's personal antithesis. Your unarmed and weapon Strikes against the creature also become magical if they weren't already.",
+		criticalFailure: "You couldn't remember the right object to use and become distracted while you rummage through your esoterica. You become flat-footed until the beginning of your next turn."
+	};
+
+	const notes = Object.entries(outcomes).map(([outcome, text]) => ({
+		title: game.i18n.localize("PF2E.Check.Result.Degree.Check." + outcome),
+		text,
+		outcome: [outcome],
+	}));
+
+	const hasDiverseLore = sa.items.some((i) => i.slug === "diverse-lore");
+	if (hasDiverseLore) {
+		// todo: put npc identify data in the document and then show secret text for it.
+		const dc = t.actor.system.details.identification?.skill.dc;
+		const diverseLoreDC = dc ? `<br/><span data-visibility="gm">Recall Knowledge DC ${dc}</span>` : "";
+		notes.push({
+			title: "Diverse Lore",
+			text: `When you succeed at your check to Exploit a Vulnerability, compare the result of your Esoteric Lore check to the DC to Recall Knowledge for that creature; if that number would be a success or a critical success, you gain information as if you had succeeded at the Recall Knowledge check. ${diverseLoreDC}`,
+			outcome: ["success", "criticalSuccess"],
+		});
+	}
+
+	const flavor = `Exploit Vulnerability: ${skill.label}`;
+	const checkModifier = new game.pf2e.CheckModifier(flavor, skill);
+	const traits = ["esoterica", "manipulate", "thaumaturge"];
+	const evRoll = await game.pf2e.Check.roll(checkModifier, {
+		actor: sa,
+		target: {
+			actor: t.actor,
+			token: t.document,
+		},
+		type: 'skill-check',
+		options: rollOptions,
+		notes,
+		dc: { value: dc },
+		traits: traits.map((t) => ({ 
+			name: t,
+			label: CONFIG.PF2E.actionTraits[t] ?? t,
+			description: CONFIG.PF2E.traitsDescriptions[t], 
+		})),
+		flavor: `
+    <strong>Frequency</strong> once per round<br/>
+    <strong>Requirements</strong> You are holding your implement<br/>
+    <hr/>
+    <p>You scour your experiences and learning to identify something that might repel your foe. You retrieve an object from your esoterica with the appropriate supernatural qualities, then use your implement to stoke the remnants of its power into a blaze. Select a creature you can see and attempt an Esoteric Lore check against a standard DC for its level, as you retrieve the right object from your esoterica and use your implement to empower it. You gain the following effects until you Exploit Vulnerabilities again.</p>
+  `,
+	}, event);
 	
-	//Exploit Vulnerability Effect/action - Trent's macro code
-	let DC = DCByLevel[t.actor.level+1];
-
-	let evRoll = await sa.skills[skillSlug].roll({
-		dc: DC,
-		target: t.actor,
-		extraRollOptions: [`action:${actionName.slugify()}`]
-	});
-
-	//handle diverse lore
-	if (sa.items.some(item => item.slug === "diverse-lore")) {
-		const DLDC = t.actor.system.details.identification?.skill.dc;
-		const DCDifference = evRoll.total - DLDC;
-		let IDDOS;
-		let DOSDetails;
-		if (evRoll.degreeOfSuccess == 2 || evRoll.degreeOfSuccess == 3) {
-			if (DCDifference <= -10) {
-				IDDOS = "Critical Failure";
-				DOSDetails = "The player recalls incorrect information or gains erroneous or misleading clues about the creature.";
-			} else if (DCDifference < 0 && DCDifference >= -10) {
-				IDDOS = "Failure";
-				DOSDetails = "The player fails to recall knowledge about the creature. <h4>Dubious Knowledge<h4><p>The player receives a bit of true knowledge and a bit of erroneous knowledge.<p>";
-			} else if (DCDifference >= 0 && DCDifference < 10) {
-				IDDOS = "Success";
-				DOSDetails = "The player recalls the knowledge accurately or gains a useful clue about the creature."
-			} else if (DCDifference >= 10) {
-				IDDOS = "Critical Success";
-				DOSDetails = "The player recalls the knowledge accurately and gains additional information or context about the creature.";
-			}
-			let _a = game.users.find(u => u.isGM);
-			await createSecretMessage(
-				{
-					blind: false,
-					flavor: `<h4>Diverse Lore - Results</h4><h4>DC ${DLDC}</h4> <p>${IDDOS} by ${DCDifference}</p><br><p>${DOSDetails}</p>`,
-					speaker: {
-						alias: "Gamemaster"
-					},
-					whisper: [null === (_a) || void 0 === _a ? void 0 : _a.id]
-				}
-			);
-		}
-		
-    }
-
-
 	const paEffectSource = await fromUuid(PERSONAL_ANTITHESIS_EFFECT_UUID);
 	const mwEffectSource = await fromUuid(MORTAL_WEAKNESS_EFFECT_UUID);
 	const flatFootedEffect = await fromUuid(FLAT_FOOTED_EFFECT_UUID);


### PR DESCRIPTION
Uses the Supe/stwlam/somebody approach of building the roll from scratch to provide a degree of success context to the card along with diverse lore notes (and private diverse lore DC to GM).