### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/src/languages/fr.json
+++ b/src/languages/fr.json
@@ -28,7 +28,8 @@
         },
         "shareWeakness": {
           "noAbility": "Cet acteur n'a pas la capacité de Partager la faiblesse",
-          "noActiveMW": "Cet acteur n'a pas d'effet de Faiblesse mortelle actif"
+          "noActiveMW": "Cet acteur n'a pas d'effet de Faiblesse mortelle actif",
+          "invalidActorCount": "Sélectionnez seulement le thaumaturge qui utilise Partager les faiblesses et essayez de nouveau."
         },
         "twinWeakness": {
           "noValidEV": "Votre cible doit être affectée par Antithèse personnelle ou Faiblesse mortel pour pouvoir utiliser Faiblesse jumelle",

--- a/src/languages/zh_Hans.json
+++ b/src/languages/zh_Hans.json
@@ -31,7 +31,8 @@
         },
         "shareWeakness": {
           "noAbility": "该角色没有共享弱点专长",
-          "noActiveMW": "该角色身上没有正在生效的凡体弱点效果"
+          "noActiveMW": "该角色身上没有正在生效的凡体弱点效果",
+          "invalidActorCount": "只选择使用共享弱点的奇术师，然后再尝试一次。"
         },
         "twinWeakness": {
           "invalidTargetCount": "选择要使用孪生弱点的一个目标，且仅选择一个",


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Exploit Vulnerability/main](https://weblate.foundryvtt-hub.com/projects/pf2e-thaum-vuln/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/pf2e-thaum-vuln/-/main/horizontal-auto.svg)