### PR TITLE
Add a DC for level -2

### DIFF
--- a/src/module/feats/exploit-vulnerability/exploitVulnerability.js
+++ b/src/module/feats/exploit-vulnerability/exploitVulnerability.js
@@ -98,6 +98,7 @@ async function exploitVuln() {
     );
   }
   const dc = {
+    "-2": 12,
     "-1": 13,
     ...Object.fromEntries(
       Object.entries([


### PR DESCRIPTION
Fixes a bug with exploit vulnerability. When the weak template is applied to a level -1 creature, it will report it's level as -2 which will error the exploit vulnerability macro.