### PR TITLE
Implement would not take config for first use

### DIFF
--- a/src/module/implements/implements.js
+++ b/src/module/implements/implements.js
@@ -165,7 +165,8 @@ export async function manageImplements(event) {
             for (const i of origin.keys()) {
               const changed =
                 origin[i]?.uuid != implementUuids[i] ? true : false;
-              impDelta.push({ name: origin[i]?.name, changed: changed });
+              const name = origin[i]?.name ?? imps[i]?.name;
+              impDelta.push({ name, changed });
             }
 
             a.setFlag("pf2e-thaum-vuln", "selectedImplements", imps);


### PR DESCRIPTION
If the Manage Impements screen was empty, and an implement like a Tome was added, the initial rules data would not get added to that implement because the name of the implement is drawn from the existing implement. If the existing implement does not exist, use the name of the newly selected one instead.


Be a Tome Thaumaturge, Steps to reproduce, create a new equipment to piece to act as the Tome. Open Manage Implements and drag the Tome to the slot. When the application has finished the Tome does not have any rules, because the name is undefined, and https://github.com/mysurvive/pf2e-thaum-vuln/blob/40a9e30c718dfbe5aa31b5466c60c487c3b814ca/src/module/implements/implementBenefits/tome.js#L397C4-L397C49 tries to compare to the name Tome.