### PR TITLE
Send result of RK check back to user who made it

### DIFF
--- a/src/module/actions/recallKnowledge.js
+++ b/src/module/actions/recallKnowledge.js
@@ -1,7 +1,7 @@
 import { createRKDialog } from "../socket";
 function recallEsotericKnowledge() {
   const sa = canvas.tokens.controlled[0].actor;
-  const targ = Array.from(game.user?.targets)[0];
+  const targ = game.user.targets.first();
   const skill =
     sa.skills["esoteric-lore"] ??
     sa.skills["esoteric"] ??


### PR DESCRIPTION
The GM actually does the roll, so the user who made the request didn't get the result.

Use a socket function to send the result back to them.  This means we need also need to tell createRKDialog() the user, not just the actor, who did the roll.

The callback doesn't do anything, but things that trigger on RK checks could put hooks in there, like Tome Adept benefit.