### PR TITLE
Implement helper to get implement data

### DIFF
--- a/src/module/implements/helpers.js
+++ b/src/module/implements/helpers.js
@@ -39,4 +39,10 @@ function checkFeatValidity(a) {
   return true;
 }
 
-export { checkImplements, checkFeatValidity };
+// Returns implement data for named implement, or undefined if that implement isn't
+// present.
+function getImplement(actor, implement) {
+  return actor.getFlag("pf2e-thaum-vuln", "selectedImplements")[implement];
+}
+
+export { checkImplements, checkFeatValidity, getImplement };


### PR DESCRIPTION
This will find the implement data in the flags and return it, or null if the implement isn't one the actor has.  The implement is specified via a slug-like name, e.g. "tome", or "weapon".  It's not for user display and wouldn't be translated.

Currently it uses a kludge method of translating the slug into the localized implement name, and then looking for a flag with a matching label.  But this could change and then users of the helper would all just keep working but with whatever faster and more reliable method gets used.