### PR TITLE
Use implement helper

### DIFF
--- a/src/module/implements/helpers.js
+++ b/src/module/implements/helpers.js
@@ -39,4 +39,10 @@ function checkFeatValidity(a) {
   return true;
 }
 
-export { checkImplements, checkFeatValidity };
+// Returns implement data for named implement, or undefined if that implement isn't
+// present.
+function getImplement(actor, implement) {
+  return actor.getFlag("pf2e-thaum-vuln", "selectedImplements")[implement];
+}
+
+export { checkImplements, checkFeatValidity, getImplement };

--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -1,11 +1,9 @@
 import { applyAbeyanceEffects } from "../../socket";
 import { INTENSIFY_VULNERABILITY_AMULET_EFFECT_UUID } from "../../utils";
+import { getImplement } from "../helpers";
 
 async function amuletsAbeyance(a, allies, strikeDamageTypes) {
-  const amuletImplementData = a.getFlag(
-    "pf2e-thaum-vuln",
-    "selectedImplements"
-  )["amulet"];
+  const amuletImplementData = getImplement(a, "amulet");
   const adeptResistanceValue = a.level < 15 ? 5 : 10;
   const abeyanceResistanceValue = 2 + a.level;
 
@@ -48,11 +46,7 @@ async function amuletsAbeyance(a, allies, strikeDamageTypes) {
                   abeyanceDamageType: damageTypes,
                 };
 
-                if (
-                  character.getFlag("pf2e-thaum-vuln", "selectedImplements")[
-                    "amulet"
-                  ].adept === true
-                ) {
+                if (getImplement(character, "amulet")?.adept) {
                   for (const selector of $(dgEndContent).find("select")) {
                     if (
                       selector.id === "damage-type-" + chosenUuid ||
@@ -78,10 +72,7 @@ async function amuletsAbeyance(a, allies, strikeDamageTypes) {
       render: () => {
         $(document).ready(function () {
           const character = a;
-          if (
-            character.getFlag("pf2e-thaum-vuln", "selectedImplements")["amulet"]
-              .paragon === true
-          ) {
+          if (getImplement(character, "amulet")?.paragon) {
             $(".character-button").css("background-color", "red");
             $(".character-button").attr("chosen", true);
           }
@@ -126,10 +117,7 @@ export const amuletChatButton = {
       ) {
         const effectRange = 15;
         const targets = message.flags["pf2e-thaum-vuln"].targets;
-        const amuletImplementData = a.actor.getFlag(
-          "pf2e-thaum-vuln",
-          "selectedImplements"
-        )["amulet"];
+        const amuletImplementData = getImplement(a.actor, "amulet");
         let targetedAlliesInRange = new Array();
         if (amuletImplementData?.paragon === true) {
           targetedAlliesInRange = canvas.tokens.placeables.filter(
@@ -167,11 +155,7 @@ export const amuletChatButton = {
           }
         }
 
-        const amuletUuid = a.actor.getFlag(
-          "pf2e-thaum-vuln",
-          "selectedImplements"
-        )["amulet"].uuid;
-
+        const amuletUuid = getImplement(a.actor, "amulet")?.uuid;
         const amulet = amuletUuid ? await fromUuid(amuletUuid) : undefined;
         const diceTotalArea = html.find(".dice-roll.damage-roll");
 
@@ -239,17 +223,13 @@ export async function amuletIntensify() {
   const a = game.user?.character?.actor ?? canvas.tokens.controlled[0]?.actor;
   if (
     !a.items.some((i) => i.slug === "intensify-vulnerability") ||
-    !a
-      .getFlag("pf2e-thaum-vuln", "selectedImplements")
-      .some((i) => i?.name === "Amulet")
+    !getImplement(a, "amulet")
   )
     return ui.notifications.warn(
       "You do not have the ability to Intensify Vulnerability. Check your sheet to make sure you have Intensify Vulnerability and you have the Amulet implement chosen."
     );
 
-  const amuletUuid = a.getFlag("pf2e-thaum-vuln", "selectedImplements")[
-    "amulet"
-  ].uuid;
+  const amuletUuid = getImplement(a, "amulet")?.uuid;
   const amulet = amuletUuid ? await fromUuid(amuletUuid) : undefined;
   if (!amulet?.isHeld)
     return ui.notifications.warn(

--- a/src/module/implements/implementBenefits/tome.js
+++ b/src/module/implements/implementBenefits/tome.js
@@ -3,66 +3,42 @@ import {
   TOME_IMPLEMENT_BENEFIT_EFFECT_UUID,
 } from "../../utils";
 import { manageImplements } from "../implements";
+import { getImplement } from "../helpers";
 
 async function createTomeDialog(actor) {
-  const classNameArray = actor?.class?.name.split(" ") ?? [];
-  if (
-    classNameArray.includes(game.i18n.localize("PF2E.TraitThaumaturge")) &&
-    actor
-      .getFlag("pf2e-thaum-vuln", "selectedImplements")
-      .some(
-        (i) =>
-          i.name ===
-          game.i18n.localize("PF2E.SpecificRule.Thaumaturge.Implement.Tome")
-      )
-  ) {
-    if (
-      actor
-        .getFlag("pf2e-thaum-vuln", "selectedImplements")
-        .find(
-          (i) =>
-            i.name ===
-            game.i18n.localize("PF2E.SpecificRule.Thaumaturge.Implement.Tome")
-        ).uuid
-    ) {
-      const tome = await fromUuid(
-        actor
-          .getFlag("pf2e-thaum-vuln", "selectedImplements")
-          .find(
-            (i) =>
-              i.name ===
-              game.i18n.localize("PF2E.SpecificRule.Thaumaturge.Implement.Tome")
-          ).uuid
-      );
+  const tomeFlags = getImplement(actor, "tome");
+  if (!tomeFlags) return;
 
-      new Dialog(
-        {
-          title: "Tome Implement Daily Preparation",
-          content: () =>
-            `<p>Would you like to change your Tome Implement skills?</p>`,
-          buttons: {
-            yes: {
-              label: game.i18n.localize("pf2e-thaum-vuln.dialog.yes"),
-              callback: () => {
-                constructEffect(actor, tome);
-              },
-            },
-            no: {
-              label: game.i18n.localize("pf2e-thaum-vuln.dialog.no"),
-              callback: () => {},
+  if (tomeFlags.uuid) {
+    const tome = await fromUuid(tomeFlags.uuid);
+
+    new Dialog(
+      {
+        title: "Tome Implement Daily Preparation",
+        content: () =>
+          `<p>Would you like to change your Tome Implement skills?</p>`,
+        buttons: {
+          yes: {
+            label: game.i18n.localize("pf2e-thaum-vuln.dialog.yes"),
+            callback: () => {
+              constructEffect(actor, tome);
             },
           },
-          default: "yes",
+          no: {
+            label: game.i18n.localize("pf2e-thaum-vuln.dialog.no"),
+            callback: () => {},
+          },
         },
-        actor,
-        tome
-      ).render(true);
-    } else {
-      manageImplements(actor);
-      return ui.notifications.warn(
-        "No Tome implement has been managed. Opening Implement Management sheet."
-      );
-    }
+        default: "yes",
+      },
+      actor,
+      tome
+    ).render(true);
+  } else {
+    manageImplements(actor);
+    return ui.notifications.warn(
+      "No Tome implement has been managed. Opening Implement Management sheet."
+    );
   }
 }
 

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -6,6 +6,7 @@ import {
   PRIMARY_TARGET_EFFECT_UUID,
 } from "./utils/index.js";
 import { parseHTML } from "./utils/utils.js";
+import { getImplement } from "./implements/helpers.js";
 
 let socket;
 
@@ -330,15 +331,9 @@ async function _createRKDialog(userId, saUuid, targUuid) {
   }).render(true);
 }
 
-async function _socketApplyAbeyanceEffects(a, abeyanceData) {
-  a = await fromUuid(a);
-  const amuletImplementData = a.flags[
-    "pf2e-thaum-vuln"
-  ].selectedImplements.find(
-    (i) =>
-      i.name ===
-      game.i18n.localize("PF2E.SpecificRule.Thaumaturge.Implement.Amulet")
-  );
+async function _socketApplyAbeyanceEffects(actorUuid, abeyanceData) {
+  const a = await fromUuid(actorUuid);
+  const amuletImplementData = getImplement(a, "amulet");
 
   for (const character in abeyanceData) {
     const amuletsAbeyanceEffect = (


### PR DESCRIPTION
Fixes a bug in socket.js that affects Amulet.

    Use getImplement for tome, amulet

    Somewhat shorter.  Also, should be easier to change things with the
    flags without having to edit as much code afterward.

    This also removes the check for having the Thaumaturge class from the
    Tome dialog.  It's faster to check for the implement flags than to check
    for the class, and a non-thaum wouldn't have the implement flags.

    And if the actor isn't a thaum, but has the flags, then they must be
    some kind of archetype or homebrew thing that gets a thaum implement's
    abilities.  And so giving the implement benefits would be the correct
    thing to do.