### PR TITLE
For tome RK, hook createChatMessage rather than render

### DIFF
--- a/src/module/implements/implementBenefits/tome.js
+++ b/src/module/implements/implementBenefits/tome.js
@@ -441,16 +441,16 @@ Hooks.on("deleteImplementEffects", (a) => {
   deleteOldTomeEffect(oldTome);
 });
 
-Hooks.on("renderChatMessage", (message) => {
+Hooks.on("createChatMessage", (message) => {
   if (
-    !game.ready ||
-    message.actor.primaryUpdater !== game.user ||
-    !message.flags.pf2e?.context?.options.some(
+    game.ready &&
+    message.flags.pf2e?.context?.type === "attack-roll" &&
+    message.flags.pf2e?.context?.options?.some(
       (o) => o === "target:mark:tome-adept-rk-success"
     )
-  )
-    return;
-  message.actor.itemTypes.effect
-    .find((i) => i.sourceId === TOME_ADEPT_RK_EFFECT_UUID)
-    ?.delete();
+  ) {
+    message.actor.itemTypes.effect
+      .find((i) => i.sourceId === TOME_ADEPT_RK_EFFECT_UUID)
+      ?.delete();
+  }
 });


### PR DESCRIPTION
renderChatMessage is run on every client for every message.  It runs on the old messages in chat history when the client starts.  We don't want to do stuff in response to those.  Using !game.ready avoids that.

But if one scrolls back past the last 100 messages, foundry will render the next 50 older messages.  In this case, the game is ready, so we act on those messages like they are a bunch of new strikes or whatever the message is.

I think the best way to avoid this is to instead hook createChatMessage. This is only run once, when the message is first created, and only on the client of the user who is doing the thing that creates the message.

So not only does it avoid the chat history problem, it also avoids even running at all on old messages and avoid running on all clients, only to do nothing except for the primaryUpdater of the actor.