### PR TITLE
Speed up amulet some

### DIFF
--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -1,8 +1,5 @@
 import { applyAbeyanceEffects } from "../../socket";
-import {
-  AMULET_FEAT_SOURCEID,
-  INTENSIFY_VULNERABILITY_AMULET_EFFECT_UUID,
-} from "../../utils";
+import { INTENSIFY_VULNERABILITY_AMULET_EFFECT_UUID } from "../../utils";
 import { getImplement } from "../helpers";
 
 async function amuletsAbeyance(a, allies, strikeDamageTypes) {
@@ -109,9 +106,7 @@ export const amuletChatButton = {
     for (const a of aArray) {
       if (
         a?.actor.isOwner &&
-        a?.actor?.itemTypes.feat.some(
-          (i) => i.sourceId === AMULET_FEAT_SOURCEID
-        ) &&
+        getImplement(a.actor, "amulet") &&
         !game.settings.get("pf2e-thaum-vuln", "reactionCheckerHandlesAmulet")
       ) {
         const effectRange = 15;


### PR DESCRIPTION
When any player applies damage, all players have their abeyance all damage resistance effect removed.

This means if an effect damages multiple players and a thaum with amulet paragon uses abeyance, only the first player to apply damage can use the effect, even though all players get it.  As soon as the first player takes damage, all the rest get their effect deleted.

The code was also somewhat slow.  It would search every item of every token on the scene looking for abeyance effects to delete, and every user would do this for all chat messages with damage, even old ones or other players' messages.

A number of speedups are used.

First we hook createChatMessage instead of renderChatMessage.  The former only happens once, and only on the client of the user creating the messages (i.e., the user applying the damage to an actor).  While the latter happens on all clients, and happens again for all messages each time the client connects.

Next, we can find out if the message is a damage application one just by checking the message object for a flag.  This faster than parsing through all the html looking for a section.

Then we only need to look at the actor in the message is about, since we don't want to remove the effect from actors who haven't taken their damage yet.  Those actors will get it removed when they take the damage and trigger the hook.

We also speed it up by reducing the number of network steps.  Before it sent a chat message that the player has taken damage to the server, and thence to the GM, which then acted on it and sent a command to delete
the effect back to the server, and thence to the player.  So we have four player<->server messages before we see it go away.

Now the same player action as applying the damage also generates the command to delete the effect, without any messages to the GM and back.