### PR TITLE
Use preCreateChatMessage rather than createChatMessage

### DIFF
--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -245,6 +245,6 @@ Hooks.on("renderChatMessage", async (message, html) => {
   amuletChatButton.listen(message, html);
 });
 
-Hooks.on("createChatMessage", async (message) => {
+Hooks.on("preCreateChatMessage", async (message) => {
   checkChatForAbeyanceEffect(message);
 });

--- a/src/module/implements/implementBenefits/tome.js
+++ b/src/module/implements/implementBenefits/tome.js
@@ -441,7 +441,7 @@ Hooks.on("deleteImplementEffects", (a) => {
   deleteOldTomeEffect(oldTome);
 });
 
-Hooks.on("createChatMessage", (message) => {
+Hooks.on("preCreateChatMessage", (message) => {
   if (
     game.ready &&
     message.flags.pf2e?.context?.type === "attack-roll" &&


### PR DESCRIPTION
The former is only called once, for the client who creates the message, before it's acutally done, and has the option to disable creating the message by returning flase.

The latter is also called once when the message is made, after it's done, can't prevent it from getting created, and for every client.  I didn't notice that last difference, and the rest seem like a better choice.