### PR TITLE
Fix Amulet's Abeyance

### DIFF
--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -8,7 +8,7 @@ class Amulet extends Implement {
     super(actor, implementItem, [], "amulet");
   }
 
-  async listenForAbeyanceChat(message, html) {
+  static async listenForAbeyanceChat(message, html) {
     if (!game.ready) return;
     const aArray =
       game.canvas.tokens.placeables.filter(
@@ -177,7 +177,7 @@ class Amulet extends Implement {
     ).render(true, { width: 750 });
   }
 
-  async checkChatForAbeyanceEffect(message) {
+  static async checkChatForAbeyanceEffect(message) {
     if (
       !game.ready ||
       game.settings.get("pf2e-thaum-vuln", "reactionCheckerHandlesAmulet") ||
@@ -228,15 +228,11 @@ class Amulet extends Implement {
 }
 
 Hooks.on("renderChatMessage", async (message, html) => {
-  const _amulet = message.actor?.attributes?.implements?.["amulet"];
-  if (!_amulet) return;
-  _amulet.listenForAbeyanceChat(message, html);
+  Amulet.listenForAbeyanceChat(message, html);
 });
 
 Hooks.on("preCreateChatMessage", async (message) => {
-  const _amulet = message.actor?.attributes?.implements?.["amulet"];
-  if (!_amulet) return;
-  _amulet.checkChatForAbeyanceEffect(message);
+  Amulet.checkChatForAbeyanceEffect(message);
 });
 
 export { Amulet };


### PR DESCRIPTION
The hook methods are not necessarily run by the thaum, so they can't be part of the Amulet object since the actor might not have one.

The solution is to make them static methods.  Since they never use "this" anywhere it isn't a problem to do this and the methods don't even change at all.  Which isn't surprising, since before the Amulet class was made they worked without getting called on the thaum.

For the checkChatForAbeyanceEffect() method, this is called on the actor taking damage.  It could be the thaum, but it could be an ally too.  But this method only removes an effect, it doesn't need to know anything about the thaum, so no problem.

listenForAbeyanceChat() does need to find a thaum, but the message it's trigged on is a damage roll by an enemy and targetting the thaum or an ally.  In the ally case, neither the message actor nor the target is the thaum.  The thaum is just (maybe) within 15' of the target.  So the method can't have an Amulet object instance until it finds a thaum.