### PR TITLE
Move regalia AELike to later phase

### DIFF
--- a/src/module/implements/implementBenefits/regalia.js
+++ b/src/module/implements/implementBenefits/regalia.js
@@ -99,6 +99,7 @@ class Regalia extends Implement {
         key: "ActiveEffectLike",
         mode: "override",
         path: "flags.pf2e.followTheExpert.minimum",
+        phase: "afterDerived",
         value: 1,
       },
       {
@@ -106,6 +107,7 @@ class Regalia extends Implement {
         mode: "upgrade",
         path: "flags.pf2e.followTheExpert.bonus.trained",
         value: 3,
+        phase: "afterDerived",
         predicate: ["paragon:regalia"],
       },
       {
@@ -113,6 +115,7 @@ class Regalia extends Implement {
         mode: "upgrade",
         path: "flags.pf2e.followTheExpert.bonus.expert",
         value: 4,
+        phase: "afterDerived",
         predicate: ["paragon:regalia"],
       },
       {
@@ -120,6 +123,7 @@ class Regalia extends Implement {
         mode: "upgrade",
         path: "flags.pf2e.followTheExpert.bonus.master",
         value: 4,
+        phase: "afterDerived",
         predicate: ["paragon:regalia"],
       },
     ];

--- a/src/module/implements/implementBenefits/regalia.js
+++ b/src/module/implements/implementBenefits/regalia.js
@@ -106,9 +106,25 @@ class Regalia extends Implement {
         key: "ActiveEffectLike",
         mode: "upgrade",
         path: "flags.pf2e.followTheExpert.bonus.trained",
+        value: 2,
+        phase: "afterDerived",
+        predicate: ["adept:regalia"],
+      },
+      {
+        key: "ActiveEffectLike",
+        mode: "upgrade",
+        path: "flags.pf2e.followTheExpert.bonus.trained",
         value: 3,
         phase: "afterDerived",
         predicate: ["paragon:regalia"],
+      },
+      {
+        key: "ActiveEffectLike",
+        mode: "upgrade",
+        path: "flags.pf2e.followTheExpert.bonus.expert",
+        value: 3,
+        phase: "afterDerived",
+        predicate: ["adept:regalia"],
       },
       {
         key: "ActiveEffectLike",
@@ -124,7 +140,7 @@ class Regalia extends Implement {
         path: "flags.pf2e.followTheExpert.bonus.master",
         value: 4,
         phase: "afterDerived",
-        predicate: ["paragon:regalia"],
+        predicate: [{ or: ["paragon:regalia", "adept:regalia"] }],
       },
     ];
 


### PR DESCRIPTION
It's possible they might be applied before the RollOptions that add stuff like "paragon:regalia", since RollOptions and AELikes are both done in the same phase.