### PR TITLE
Fix some issues with Amulet's Abeyance character selection

### DIFF
--- a/src/templates/amuletsAbeyanceDialog.hbs
+++ b/src/templates/amuletsAbeyanceDialog.hbs
@@ -2,6 +2,15 @@
   .amulets-abeyance-btn-row{padding:0.5rem; display:flex; flex-wrap:wrap;
   justify-content: space-around;} .damage-type-row{display:flex;
   justify-content:center; align-items:center; padding-bottom:0.5rem;}
+  .character-button {
+    background-color: transparent;
+    background-size:contain;
+    width:10rem;
+    height:10rem;
+  }
+  .character-button[chosen] {
+    background-color: red;
+  }
 </style>
 <div class="amulets-abeyance-dialog" dmg="{{damageTypes}}">
   <div class="amulets-abeyance-flavor">
@@ -39,7 +48,7 @@
         <button
           type="button"
           class="character-button"
-          style="background: url({{document.texture.src}});background-size:contain; width:10rem; height:10rem;"
+          style="background-image:url({{document.texture.src}});"
           id="{{document.uuid}}"
         ></button>
         <p style="text-align: center">{{name}}</p>


### PR DESCRIPTION
The dialog for selecting which tokens should get the Amulet's Abeyance effect didn't actually work.

While the background color changed to/from transparent and red, none of the tokens would actually get unchosen.

The code to unselect the buttons not clicked on was using the siblings of the button clicked on.  But the button has no siblings, it's inside of a div by itself.  It's the button's parent div that has the other divs as siblings.

With paragon amulet, as soon as a token was clicked on, the dialog would enforce the non-paragon radio button behavior of selecting only one token at a time.  Change this so paragon amulet can toggle each token individually.

Also move the common token button styles to the CSS section, instead of injecting them on each button.  Make the background color based on having the "chosen" attribute or not in the CSS, so it doesn't need to be changed in the js code based on button state.