### PR TITLE
Rework how the Amulet's Abeyance action is done

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,6 +22,9 @@ module.exports = {
     isEmpty: "readonly",
     libWrapper: "readonly",
     socketlib: "readonly",
+
+    // @typhonjs-fvtt/eslint-config-foundry.js hasn't been updated in 3 years, missing some stuff
+    fromUuidSync: "readonly",
   },
 
   extends: [

--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -4,6 +4,7 @@ import {
   PRIMARY_TARGET_EFFECT_UUID,
 } from "../../utils";
 import { getImplement } from "../helpers";
+import { messageTargetTokens } from "../../utils/helpers";
 import { Implement } from "../implement";
 
 class Amulet extends Implement {
@@ -31,11 +32,7 @@ class Amulet extends Implement {
     if (thaums.length == 0) return;
 
     // Turn target UUID list into Tokens
-    const targets =
-      message
-        .getFlag("pf2e-thaum-vuln", "targets")
-        ?.map((t) => fromUuidSync(t.tokenUuid)?.object) ?? [];
-    // Note, getFlag('pf2e', 'context.target') already exists for strike damage rolls...
+    const targets = messageTargetTokens(message);
 
     // For any thaums with the attacker as EV target, check if an allied target is within 15'
     let abeyers = [];
@@ -91,13 +88,8 @@ class Amulet extends Implement {
 
   async amuletsAbeyance(message, tokenUuid) {
     const token = fromUuidSync(tokenUuid).object;
-    // Turn target UUID list into Tokens
-    const attackTargets =
-      message
-        .getFlag("pf2e-thaum-vuln", "targets")
-        ?.map((t) => fromUuidSync(t.tokenUuid)?.object) ?? [];
     const allies = (
-      this.paragon ? canvas.tokens.placeables : attackTargets
+      this.paragon ? canvas.tokens.placeables : messageTargetTokens(message)
     ).filter((t) => this.isAbeyableToken(t, token));
 
     const dgContent = {

--- a/src/module/implements/implementBenefits/amulet.js
+++ b/src/module/implements/implementBenefits/amulet.js
@@ -110,28 +110,20 @@ class Amulet extends Implement {
       buttons: {
         confirm: {
           label: game.i18n.localize("pf2e-thaum-vuln.dialog.confirm"),
-          callback: async (dgEndContent) => {
+          callback: (dgEndContent) => {
             let abeyanceData = {};
             for (const btn of $(dgEndContent).find(
               ".character-button[chosen]"
             )) {
               const chosenUuid = $(btn).attr("id");
-              const charName = (await fromUuid(chosenUuid)).name;
-              abeyanceData[charName] = {
-                uuid: chosenUuid,
-              };
-
+              abeyanceData[chosenUuid] = {};
               if (this.adept) {
-                for (const selector of $(dgEndContent).find("select")) {
-                  if (
-                    selector.id === "damage-type-" + chosenUuid ||
-                    selector.id === "damage-type-adept"
-                  ) {
-                    const charName = (await fromUuid(chosenUuid)).name;
-                    const damageType = $(selector)[0].value;
-                    abeyanceData[charName].lingeringDamageType = damageType;
-                  }
-                }
+                const id = this.paragon
+                  ? `#damage-type-${chosenUuid.replace(/\./g, "\\.")}`
+                  : "#damage-type-adept";
+                const selector = $(dgEndContent).find(id);
+                const damageType = $(selector)[0].value;
+                abeyanceData[chosenUuid].lingeringDamageType = damageType;
               }
             }
             applyAbeyanceEffects(this.actor.uuid, abeyanceData);

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -97,9 +97,10 @@ async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
         effect.flags.core.sourceId === PERSONAL_ANTITHESIS_TARGET_SOURCEID) &&
       a.getFlag("pf2e-thaum-vuln", "primaryEVTarget") === targ
     ) {
-      const primaryEVTargetEffect = (
-        await fromUuid(PRIMARY_TARGET_EFFECT_UUID)
-      ).toObject();
+      const primaryEVTargetEffect = await createEffectData(
+        PRIMARY_TARGET_EFFECT_UUID,
+        { actor: a.uuid }
+      );
       primaryEVTargetEffect.system.slug +=
         "-" + game.pf2e.system.sluggify(a.name);
       primaryEVTargetEffect.name += ": " + a.name;

--- a/src/module/utils/helpers.js
+++ b/src/module/utils/helpers.js
@@ -152,6 +152,22 @@ async function createEffectData(uuid, origin = null) {
   return effect;
 }
 
+// Return an array of Tokens that are the targets of the message.  Message
+// should be something that has targets, like a damage roll.
+function messageTargetTokens(message) {
+  // It's ok to use fromUuidSync here since any tokens that are the targets of a
+  // current attack will surely be in the game.
+  return (
+    message
+      .getFlag("pf2e-thaum-vuln", "targets")
+      ?.map((t) => fromUuidSync(t.tokenUuid)?.object) ?? []
+  );
+
+  // The system already has a flag, getFlag('pf2e', 'context.target'), for the
+  // target of attack damage rolls.  But it's limited to one target and doesn't
+  // get set on saving throw spell damage rolls.
+}
+
 export {
   targetEVPrimaryTarget,
   getMWTargets,
@@ -160,4 +176,5 @@ export {
   getActorEVEffect,
   BDGreatestBypassableResistance,
   createEffectData,
+  messageTargetTokens,
 };


### PR DESCRIPTION
This should be more efficient, create less lag, and also fixes a few issues.

The existing code did most of the work in renderChatMessage, which is called on every chat message for every player.  Even old chat messages.

This now tries to do less work there and more in hooks that happen less often.

When the chat message is first created (when someone rolls damage) the damage roller is checked to see if it's an EV target.  This is a simple search of just the damage roller's effects.  If it is, the thaumaturge(s) targetting it are known from the EV target effect origin, and then we can check if any of the roll's targets are allies in range.

Note that rather than checking for "party" alliance, we check if the damage targets have the same alliance as the thaumaturge, so this works for "opposition" targets too.

This is bundled up as an array of "abeyers" in the message flags.  Each is an object with the actor and token UUID of a thaumaturge who can abey the damage.

Then in renderChatMessage, we just loop through the tokens in the abeyers array, if any, and add a button for the token if the current user is an owner.  No need to look at the map and find anything within 15' of something else or any other sort of O(n²) loops.

When the button is clicked, then we can do most of the work.  The callback no longer saves a reference to the amulet, as this could be stale by the time the button is clicked.  Only the actor and the message.

We find the allies in range, based on targets or all allies for paragon vs non-paragon, the damage types, and make up the dialog.

The code to find the Amulet feat isn't needed, it's already there in this.baseFeat.  And damage types don't need to be extracted from the html in dialog callback, we can use the data from when we made the dialog.  The arrow functions' closures keep refernces to items used in enclosing scopes.