### PR TITLE
Use createEffectData in more places

### DIFF
--- a/src/module/feats/esotericWarden.js
+++ b/src/module/feats/esotericWarden.js
@@ -1,10 +1,11 @@
 import { ESOTERIC_WARDEN_EFFECT_UUID } from "../utils/index.js";
+import { createEffectData } from "../utils/helpers.js";
 import { sharedWardingDialog } from "./sharedWarding.js";
 
 async function createEsotericWarden(rollDOS, EWPredicate, sa, t) {
   const hasSharedWarding = sa.items.some((i) => i.slug === "shared-warding");
 
-  let EWEffect = (await fromUuid(ESOTERIC_WARDEN_EFFECT_UUID)).toObject();
+  const EWEffect = await createEffectData(ESOTERIC_WARDEN_EFFECT_UUID);
   const bonus = rollDOS === 3 ? 2 : rollDOS === 2 ? 1 : 0;
   EWEffect.system.rules[0].value = bonus;
   EWEffect.system.rules[1].value = bonus;

--- a/src/module/feats/exploit-vulnerability/helpers.js
+++ b/src/module/feats/exploit-vulnerability/helpers.js
@@ -9,6 +9,7 @@ import {
 } from "../../utils";
 import {
   BDGreatestBypassableResistance,
+  createEffectData,
   getGreatestIWR,
   getIWR,
   getMWTargets,
@@ -92,8 +93,9 @@ async function createEffectOnActor(sa, t, effect, rollDOS) {
     iwrData = getGreatestIWR(iwrData.weaknesses)?.value;
   }
 
-  let targEffect = await fromUuid(effectPairing[evMode]);
-  targEffect = targEffect.toObject();
+  const targEffect = await createEffectData(effectPairing[evMode], {
+    actor: sa.uuid,
+  });
   targEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: sa.uuid };
   targEffect.system.slug =
     targEffect.system.slug + "-" + game.pf2e.system.sluggify(sa.name);


### PR DESCRIPTION
Fixes issues with flags.core.sourceId not being set.  Also sets the effect's origin flags when it's something going from the thaum to another actor.

There are more, but I'm only doing the ones I've looked at.