### PR TITLE
Fix for mortal weakness when sourceId of target is null

### DIFF
--- a/src/module/utils/helpers.js
+++ b/src/module/utils/helpers.js
@@ -3,7 +3,11 @@ import { TargetEffectSourceIDs } from ".";
 function getMWTargets(t) {
   let targs = new Array();
   for (let token of canvas.tokens.objects.children) {
-    if (token?.actor?.sourceId === t.actor.sourceId) {
+    if (
+      (t.actor.sourceId && token?.actor?.sourceId === t.actor.sourceId) ||
+      (t.actor.prototypeToken?.name &&
+        token?.actor?.prototypeToken?.name === t.actor.prototypeToken?.name)
+    ) {
       targs.push(token.actor.uuid);
     }
   }


### PR DESCRIPTION
I don't know why it happens, but sometimes the sourceId for an token.actor will be null.  I don't think it has anything to do with the EV module.

But if one exploits mortal weakness on a target token with a null sourceId, it will think all tokens with a null sourceId are the same type.

Change the logic to not match if the sourceId is null.

Also add a match if the prototypeToken name is the same.  This does work even if the actor name has been changed via Token Mold.