### PR TITLE
Fix up pack data when making packs

### DIFF
--- a/build/buildPacks.js
+++ b/build/buildPacks.js
@@ -1,13 +1,37 @@
 import { compilePack } from "@foundryvtt/foundryvtt-cli";
+import { TYPE_COLLECTION_MAP } from "@foundryvtt/foundryvtt-cli/lib/package.mjs";
 import fs from "fs";
 
-export async function buildModulePacks() {
+const COLLECTION_TYPE = new Map(
+  Object.entries(TYPE_COLLECTION_MAP).map(([k, v]) => [v, k])
+);
+
+export async function buildModulePacks(packageId) {
   const packsJsonPath = "./src/packs";
   const srcPacks = fs.readdirSync(packsJsonPath);
 
   for (const pack of srcPacks) {
     const packSource = `${packsJsonPath}/${pack}`;
     const packDest = `./dist/packs/${pack}`;
-    await compilePack(packSource, packDest, { log: true });
+    await compilePack(packSource, packDest, {
+      log: true,
+      transformEntry: (entry) => {
+        const [, collection] = entry._key.split("!");
+        const docType = COLLECTION_TYPE.get(collection);
+
+        // Remove obsolte sourceId flags
+        if (entry.flags?.core?.sourceId) delete entry.flags.core.sourceId;
+
+        // Add correct compendiumSource (except to folders)
+        if (collection !== "folders")
+          entry._stats.compendiumSource = `Compendium.${packageId}.${pack}.${docType}.${entry._id}`;
+
+        // Remove any user IDs, they don't work on other servers
+        for (const userId of Object.keys(entry.ownership ?? {})) {
+          if (userId !== "default") delete entry.ownership[userId];
+        }
+        if (entry._stats.lastModifiedBy) delete entry._stats.lastModifiedBy;
+      },
+    });
   }
 }

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -130,7 +130,7 @@ export async function clean() {
 /********************/
 
 async function buildPacks() {
-  await buildModulePacks();
+  await buildModulePacks(packageId);
 }
 
 /********************/

--- a/src/module/utils/index.js
+++ b/src/module/utils/index.js
@@ -2,7 +2,8 @@ const EXPLOIT_VULNERABILITY_ACTION_ID =
   "Compendium.pf2e.actionspf2e.Item.fodJ3zuwQsYnBbtk";
 const MORTAL_WEAKNESS_EFFECT_UUID =
   "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.N0jy0FFGS7ViTvs9";
-const MORTAL_WEAKNESS_COMPENDIUM_SOURCE = "Item.plf15q5mFglgWG8w";
+const MORTAL_WEAKNESS_COMPENDIUM_SOURCE =
+  "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.N0jy0FFGS7ViTvs9";
 const PERSONAL_ANTITHESIS_EFFECT_UUID =
   "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.EGY7Rxcxwv1aEyHL";
 const OFF_GUARD_EFFECT_UUID =

--- a/src/packs/mysurvives-thaumaturge-macros/cursed-effigy.json
+++ b/src/packs/mysurvives-thaumaturge-macros/cursed-effigy.json
@@ -6,13 +6,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/cursed-effigy.webp",
   "command": "game.pf2eThaumVuln.cursedEffigy();",
   "ownership": {
-    "default": 0,
-    "yndSwxb2e9oSc8iR": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Macro.QnIp0RIvqKiWgWBC"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -20,8 +17,7 @@
     "coreVersion": "12.327",
     "createdTime": 1680591137980,
     "modifiedTime": 1680591314710,
-    "lastModifiedBy": "yndSwxb2e9oSc8iR",
-    "compendiumSource": "Macro.QnIp0RIvqKiWgWBC",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.e7wMFPmQcOq5mGze",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/mysurvives-thaumaturge-macros/drink-from-the-chalice.json
+++ b/src/packs/mysurvives-thaumaturge-macros/drink-from-the-chalice.json
@@ -9,8 +9,7 @@
   "folder": null,
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -19,8 +18,7 @@
     "coreVersion": "12.327",
     "createdTime": 1716581770915,
     "modifiedTime": 1716581861960,
-    "lastModifiedBy": "o29bm85va79jJPjh",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.OjbmMO3RrNE0t78D",
     "duplicateSource": null
   },
   "_key": "!macros!OjbmMO3RrNE0t78D"

--- a/src/packs/mysurvives-thaumaturge-macros/exploit-vulnerability.json
+++ b/src/packs/mysurvives-thaumaturge-macros/exploit-vulnerability.json
@@ -6,13 +6,10 @@
   "img": "systems/pf2e/icons/features/classes/exploit-vulnerability.webp",
   "command": "game.pf2eThaumVuln.exploitVuln();",
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Macro.3AAK0OwRuaf6EzK2"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -20,8 +17,7 @@
     "coreVersion": "12.327",
     "createdTime": 1674186218786,
     "modifiedTime": 1674253748176,
-    "lastModifiedBy": "stoRK7j13Ug3rYKp",
-    "compendiumSource": "Macro.3AAK0OwRuaf6EzK2",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.4psB1vhpWnm4JUQc",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/mysurvives-thaumaturge-macros/force-ev.json
+++ b/src/packs/mysurvives-thaumaturge-macros/force-ev.json
@@ -6,13 +6,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/mortal-weakness.webp",
   "command": "game.pf2eThaumVuln.forceEVTarget();",
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Macro.tNbHsrluG6x9tHe4"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -20,8 +17,7 @@
     "coreVersion": "12.327",
     "createdTime": 1674521780250,
     "modifiedTime": 1675096450539,
-    "lastModifiedBy": "stoRK7j13Ug3rYKp",
-    "compendiumSource": "Macro.tNbHsrluG6x9tHe4",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.TILYwPmRAg2HJ3JO",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/mysurvives-thaumaturge-macros/intensify-vulnerability.json
+++ b/src/packs/mysurvives-thaumaturge-macros/intensify-vulnerability.json
@@ -9,8 +9,7 @@
   "folder": null,
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -19,8 +18,7 @@
     "coreVersion": "12.327",
     "createdTime": 1711917759064,
     "modifiedTime": 1716191644098,
-    "lastModifiedBy": "o29bm85va79jJPjh",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.0TZaFJxM9ttQsbfT",
     "duplicateSource": null
   },
   "_key": "!macros!0TZaFJxM9ttQsbfT"

--- a/src/packs/mysurvives-thaumaturge-macros/recall-knowledge-esoteric-lore.json
+++ b/src/packs/mysurvives-thaumaturge-macros/recall-knowledge-esoteric-lore.json
@@ -7,8 +7,7 @@
   "command": "game.pf2eThaumVuln.recallEsotericKnowledge();",
   "folder": null,
   "ownership": {
-    "default": 0,
-    "21SSsb3mHHUoxQru": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -19,8 +18,7 @@
     "coreVersion": "12.327",
     "createdTime": 1687770227013,
     "modifiedTime": 1687771284497,
-    "lastModifiedBy": "21SSsb3mHHUoxQru",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.EC0oy6caGQ4zECU6",
     "duplicateSource": null
   },
   "_id": "EC0oy6caGQ4zECU6",

--- a/src/packs/mysurvives-thaumaturge-macros/root-to-life.json
+++ b/src/packs/mysurvives-thaumaturge-macros/root-to-life.json
@@ -9,8 +9,7 @@
   "folder": null,
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "SfdMUCysDxSnaHSF": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -19,8 +18,7 @@
     "coreVersion": "12.327",
     "createdTime": 1697484921571,
     "modifiedTime": 1697485027142,
-    "lastModifiedBy": "SfdMUCysDxSnaHSF",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.z4OSMt56EvarOV3a",
     "duplicateSource": null
   },
   "_key": "!macros!z4OSMt56EvarOV3a"

--- a/src/packs/mysurvives-thaumaturge-macros/share-weakness.json
+++ b/src/packs/mysurvives-thaumaturge-macros/share-weakness.json
@@ -6,13 +6,10 @@
   "img": "icons/svg/dice-target.svg",
   "command": "game.pf2eThaumVuln.shareWeakness();",
   "ownership": {
-    "default": 0,
-    "yndSwxb2e9oSc8iR": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Macro.E7sOHdjlP31VMxvG"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -20,8 +17,7 @@
     "coreVersion": "12.327",
     "createdTime": 1680591087861,
     "modifiedTime": 1680591130493,
-    "lastModifiedBy": "yndSwxb2e9oSc8iR",
-    "compendiumSource": "Macro.E7sOHdjlP31VMxvG",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.mfsf7DkcE14KDUjE",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/mysurvives-thaumaturge-macros/twin-weakness.json
+++ b/src/packs/mysurvives-thaumaturge-macros/twin-weakness.json
@@ -6,13 +6,10 @@
   "img": "icons/svg/dice-target.svg",
   "command": "game.pf2eThaumVuln.twinWeakness();",
   "ownership": {
-    "default": 0,
-    "yndSwxb2e9oSc8iR": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Macro.enhRQBIu4g7DpUaV"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -20,8 +17,7 @@
     "coreVersion": "12.327",
     "createdTime": 1680591195268,
     "modifiedTime": 1680591211685,
-    "lastModifiedBy": "yndSwxb2e9oSc8iR",
-    "compendiumSource": "Macro.enhRQBIu4g7DpUaV",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.mysurvives-thaumaturge-macros.Macro.u5K6HYOTUVFoUCMY",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/breached-defenses-target.json
+++ b/src/packs/thaumaturge-effects/breached-defenses-target.json
@@ -51,13 +51,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/breached-defenses.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.aasC0M4NDDjR84UI"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -65,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1675817794143,
     "modifiedTime": 1721825745998,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.aasC0M4NDDjR84UI",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.E38yjK1tdr579dJy",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/breached-defenses.json
+++ b/src/packs/thaumaturge-effects/breached-defenses.json
@@ -83,13 +83,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/breached-defenses.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.9ZJclirw6zHSkk0n"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -97,8 +94,7 @@
     "coreVersion": "12.329",
     "createdTime": 1675815751178,
     "modifiedTime": 1721825748891,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.9ZJclirw6zHSkk0n",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.FMw5IpJdA6eOgtv1",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/cursed-effigy.json
+++ b/src/packs/thaumaturge-effects/cursed-effigy.json
@@ -61,13 +61,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/cursed-effigy.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.XDXJA884X2AYJ0RO"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -75,8 +72,7 @@
     "coreVersion": "12.329",
     "createdTime": 1678227898148,
     "modifiedTime": 1721825743606,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.XDXJA884X2AYJ0RO",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.s0NI9gKZygLUunOg",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/effect-amulets-abeyance-lingering-resistance.json
+++ b/src/packs/thaumaturge-effects/effect-amulets-abeyance-lingering-resistance.json
@@ -51,8 +51,7 @@
   "img": "systems/pf2e/icons/features/classes/amulet.webp",
   "folder": "nRJn8lCp56aa4sVJ",
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1693263866974,
     "modifiedTime": 1721825804361,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.zo2vRmRcEWLNwPIN",
     "duplicateSource": null
   },
   "_id": "zo2vRmRcEWLNwPIN",

--- a/src/packs/thaumaturge-effects/effect-amulets-abeyance.json
+++ b/src/packs/thaumaturge-effects/effect-amulets-abeyance.json
@@ -51,8 +51,7 @@
   "img": "systems/pf2e/icons/features/classes/amulet.webp",
   "folder": "nRJn8lCp56aa4sVJ",
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1693263866974,
     "modifiedTime": 1721825794184,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.FWdzwEJBJjq18Zep",
     "duplicateSource": null
   },
   "_id": "FWdzwEJBJjq18Zep",

--- a/src/packs/thaumaturge-effects/effect-chalice-adept-enabled.json
+++ b/src/packs/thaumaturge-effects/effect-chalice-adept-enabled.json
@@ -48,8 +48,7 @@
   "img": "systems/pf2e/icons/features/classes/chalice.webp",
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -58,8 +57,7 @@
     "coreVersion": "12.329",
     "createdTime": 1716533295630,
     "modifiedTime": 1721825831489,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.Zl40i1PmitlIxZIK",
     "duplicateSource": null
   },
   "_key": "!items!Zl40i1PmitlIxZIK"

--- a/src/packs/thaumaturge-effects/effect-chalice-drained.json
+++ b/src/packs/thaumaturge-effects/effect-chalice-drained.json
@@ -46,8 +46,7 @@
   "img": "systems/pf2e/icons/features/classes/chalice.webp",
   "folder": "49RonrSVUq7rxVLo",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -58,8 +57,7 @@
     "coreVersion": "12.329",
     "createdTime": 1716158041927,
     "modifiedTime": 1721825828395,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.n8n4HXjbVblq9WBj",
     "duplicateSource": null
   },
   "_id": "n8n4HXjbVblq9WBj",

--- a/src/packs/thaumaturge-effects/effect-chalice-intensify-enabled.json
+++ b/src/packs/thaumaturge-effects/effect-chalice-intensify-enabled.json
@@ -48,8 +48,7 @@
   "img": "systems/pf2e/icons/features/classes/chalice.webp",
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -58,8 +57,7 @@
     "coreVersion": "12.329",
     "createdTime": 1716586601660,
     "modifiedTime": 1721825825697,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.MKztdugJAUnHLfE2",
     "duplicateSource": null
   },
   "_key": "!items!MKztdugJAUnHLfE2"

--- a/src/packs/thaumaturge-effects/effect-chalice-temp-hp.json
+++ b/src/packs/thaumaturge-effects/effect-chalice-temp-hp.json
@@ -51,8 +51,7 @@
   "img": "systems/pf2e/icons/features/classes/chalice.webp",
   "folder": "49RonrSVUq7rxVLo",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1716181679619,
     "modifiedTime": 1721825823295,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.ZLBlD9tMHjrNLhIn",
     "duplicateSource": null
   },
   "_id": "ZLBlD9tMHjrNLhIn",

--- a/src/packs/thaumaturge-effects/effect-in-lantern-light-ally.json
+++ b/src/packs/thaumaturge-effects/effect-in-lantern-light-ally.json
@@ -77,13 +77,10 @@
   "img": "icons/sundries/lights/lantern-iron-yellow.webp",
   "folder": "uZeUODrn3vPGUdvC",
   "ownership": {
-    "default": 0,
-    "JCSogeTR741olRmm": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.pUHhRMzKWkHeHUo4"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -91,7 +88,6 @@
     "coreVersion": "12.329",
     "createdTime": 1715485019258,
     "modifiedTime": 1721825837064,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.pUHhRMzKWkHeHUo4",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-in-lantern-light-enemy.json
+++ b/src/packs/thaumaturge-effects/effect-in-lantern-light-enemy.json
@@ -59,13 +59,10 @@
   "img": "icons/sundries/lights/lantern-iron-yellow.webp",
   "folder": "uZeUODrn3vPGUdvC",
   "ownership": {
-    "default": 0,
-    "JCSogeTR741olRmm": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.NPPu2y73JHbTrSE3"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -73,7 +70,6 @@
     "coreVersion": "12.329",
     "createdTime": 1715486634382,
     "modifiedTime": 1721825840881,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.NPPu2y73JHbTrSE3",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-amulet.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-amulet.json
@@ -72,13 +72,10 @@
   "img": "systems/pf2e/icons/features/classes/amulet.webp",
   "folder": "nRJn8lCp56aa4sVJ",
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.icPIf1hOBOVmWtL1"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -86,7 +83,6 @@
     "coreVersion": "12.329",
     "createdTime": 1693312537676,
     "modifiedTime": 1721825801135,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.icPIf1hOBOVmWtL1",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-chalice.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-chalice.json
@@ -48,8 +48,7 @@
   "img": "systems/pf2e/icons/features/classes/chalice.webp",
   "sort": 0,
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -58,8 +57,7 @@
     "coreVersion": "12.329",
     "createdTime": 1716410693630,
     "modifiedTime": 1721825821087,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.AGSDsV0CL1Bx681Z",
     "duplicateSource": null
   },
   "_key": "!items!AGSDsV0CL1Bx681Z"

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-lantern.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-lantern.json
@@ -92,13 +92,10 @@
   "img": "systems/pf2e/icons/equipment/adventuring-gear/lantern.webp",
   "sort": 200000,
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.atECc1SuDgUqNakg"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -106,7 +103,6 @@
     "coreVersion": "12.329",
     "createdTime": 1700515498054,
     "modifiedTime": 1721825843649,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.atECc1SuDgUqNakg",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia-critical-success.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia-critical-success.json
@@ -61,13 +61,10 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.CGANYKdu4lVXj0nk"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -75,7 +72,6 @@
     "coreVersion": "12.329",
     "createdTime": 1713627684011,
     "modifiedTime": 1721825863215,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.CGANYKdu4lVXj0nk",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia-success.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia-success.json
@@ -61,13 +61,10 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.gEfHdas8he98C9rR"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -75,7 +72,6 @@
     "coreVersion": "12.329",
     "createdTime": 1713627684011,
     "modifiedTime": 1721825860969,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.gEfHdas8he98C9rR",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-regalia.json
@@ -71,13 +71,10 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.qHe8lT8ROOKwFNkg"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -85,7 +82,6 @@
     "coreVersion": "12.329",
     "createdTime": 1713627157805,
     "modifiedTime": 1721825865782,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.qHe8lT8ROOKwFNkg",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-tome.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-tome.json
@@ -70,13 +70,10 @@
   "img": "systems/pf2e/icons/features/classes/tome.webp",
   "folder": "jOCeu91o3wpQtjdd",
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.d0gHXzfsHj6OpV54"
-    },
+    "core": {},
     "pf2e-thaum-vuln": {}
   },
   "_stats": {
@@ -85,7 +82,6 @@
     "coreVersion": "12.329",
     "createdTime": 1693607168441,
     "modifiedTime": 1721825874958,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.d0gHXzfsHj6OpV54",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-intensify-vulnerability-weapon.json
+++ b/src/packs/thaumaturge-effects/effect-intensify-vulnerability-weapon.json
@@ -57,13 +57,10 @@
   "img": "systems/pf2e/icons/features/classes/weapon.webp",
   "folder": "2AI4ZiPu2VqKEvPx",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.9tc7D61ZL6yzXYZ2"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -71,7 +68,6 @@
     "coreVersion": "12.329",
     "createdTime": 1713630955161,
     "modifiedTime": 1721825886860,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.9tc7D61ZL6yzXYZ2",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/effect-primary-ev-target.json
+++ b/src/packs/thaumaturge-effects/effect-primary-ev-target.json
@@ -51,8 +51,7 @@
   "img": "modules/pf2e-thaum-vuln/assets/personal-antithesis-primary.webp",
   "folder": null,
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1693317776285,
     "modifiedTime": 1721825780294,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.E0X9AYLqXSaiO9A3",
     "duplicateSource": null
   },
   "_id": "E0X9AYLqXSaiO9A3",

--- a/src/packs/thaumaturge-effects/effect-regalia-aura-adept.json
+++ b/src/packs/thaumaturge-effects/effect-regalia-aura-adept.json
@@ -85,8 +85,7 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -97,8 +96,7 @@
     "coreVersion": "12.329",
     "createdTime": 1706455561720,
     "modifiedTime": 1721825858648,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.lr1UVbxaToPGdSvw",
     "duplicateSource": null
   },
   "_id": "lr1UVbxaToPGdSvw",

--- a/src/packs/thaumaturge-effects/effect-regalia-aura-initiate.json
+++ b/src/packs/thaumaturge-effects/effect-regalia-aura-initiate.json
@@ -61,8 +61,7 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -73,8 +72,7 @@
     "coreVersion": "12.329",
     "createdTime": 1706455561720,
     "modifiedTime": 1721825856266,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.W0hOUNf7dJHmJ63j",
     "duplicateSource": null
   },
   "_id": "W0hOUNf7dJHmJ63j",

--- a/src/packs/thaumaturge-effects/effect-regalia-aura-paragon.json
+++ b/src/packs/thaumaturge-effects/effect-regalia-aura-paragon.json
@@ -101,8 +101,7 @@
   "img": "systems/pf2e/icons/features/classes/regalia.webp",
   "folder": "vXZGmsTW5NLQ9OQW",
   "ownership": {
-    "default": 0,
-    "o29bm85va79jJPjh": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -113,8 +112,7 @@
     "coreVersion": "12.329",
     "createdTime": 1706455561720,
     "modifiedTime": 1721825853992,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.rrxQvikt1U3qe4Jx",
     "duplicateSource": null
   },
   "_id": "rrxQvikt1U3qe4Jx",

--- a/src/packs/thaumaturge-effects/effect-tome-implement.json
+++ b/src/packs/thaumaturge-effects/effect-tome-implement.json
@@ -53,8 +53,7 @@
   "img": "systems/pf2e/icons/features/classes/tome.webp",
   "sort": 300000,
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {},
   "_stats": {
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1693367496799,
     "modifiedTime": 1721825881799,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.lDKArhqx0hBtwVRQ",
     "duplicateSource": null
   },
   "_key": "!items!lDKArhqx0hBtwVRQ"

--- a/src/packs/thaumaturge-effects/esoteric-warden-effect.json
+++ b/src/packs/thaumaturge-effects/esoteric-warden-effect.json
@@ -71,13 +71,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/esoteric-warden.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.uKh4kjbl4arTnzC4"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -85,8 +82,7 @@
     "coreVersion": "12.329",
     "createdTime": 1676928897209,
     "modifiedTime": 1721825741289,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.uKh4kjbl4arTnzC4",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.fufcXy1CEMvxmgWt",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/exploit-mortal-weakness.json
+++ b/src/packs/thaumaturge-effects/exploit-mortal-weakness.json
@@ -66,13 +66,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/mortal-weakness.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.plf15q5mFglgWG8w"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -80,8 +77,7 @@
     "coreVersion": "12.329",
     "createdTime": 1674314281214,
     "modifiedTime": 1721825774984,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.plf15q5mFglgWG8w",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.N0jy0FFGS7ViTvs9",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/exploit-personal-antithesis.json
+++ b/src/packs/thaumaturge-effects/exploit-personal-antithesis.json
@@ -66,13 +66,10 @@
   "img": "systems/pf2e/icons/features/classes/exploit-vulnerability.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.Ug14iErZQ2h2y7B2"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -80,8 +77,7 @@
     "coreVersion": "12.329",
     "createdTime": 1674314310917,
     "modifiedTime": 1721825771973,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.Ug14iErZQ2h2y7B2",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.EGY7Rxcxwv1aEyHL",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/implement-effects.json
+++ b/src/packs/thaumaturge-effects/implement-effects.json
@@ -12,8 +12,7 @@
     "systemVersion": "5.3.2",
     "coreVersion": "11.308",
     "createdTime": 1693312375935,
-    "modifiedTime": 1693312375935,
-    "lastModifiedBy": "UQu4pcNxGHCGDRdj"
+    "modifiedTime": 1693312375935
   },
   "_key": "!folders!A5LcQoSo0NG6WhAR"
 }

--- a/src/packs/thaumaturge-effects/mortal-weakness-target.json
+++ b/src/packs/thaumaturge-effects/mortal-weakness-target.json
@@ -62,13 +62,10 @@
   "img": "modules/pf2e-thaum-vuln/assets/mortal-weakness.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.q2TMJ31MwLNJV1jA"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -76,7 +73,6 @@
     "coreVersion": "12.329",
     "createdTime": 1675061979938,
     "modifiedTime": 1721825768641,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.q2TMJ31MwLNJV1jA",
     "duplicateSource": null
   },

--- a/src/packs/thaumaturge-effects/off-guard-ev-critical-failure.json
+++ b/src/packs/thaumaturge-effects/off-guard-ev-critical-failure.json
@@ -60,13 +60,10 @@
   "img": "systems/pf2e/icons/conditions/off-guard.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.E5cNWuuvOLWVhAcB"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -74,8 +71,7 @@
     "coreVersion": "12.329",
     "createdTime": 1675386402884,
     "modifiedTime": 1721825729055,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.E5cNWuuvOLWVhAcB",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.Xuwb7a6jCWkFS0lI",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/personal-antithesis-target.json
+++ b/src/packs/thaumaturge-effects/personal-antithesis-target.json
@@ -62,13 +62,10 @@
   "img": "systems/pf2e/icons/features/classes/exploit-vulnerability.webp",
   "effects": [],
   "ownership": {
-    "default": 0,
-    "stoRK7j13Ug3rYKp": 3
+    "default": 0
   },
   "flags": {
-    "core": {
-      "sourceId": "Item.5QgPHAdpsUHJmCkX"
-    }
+    "core": {}
   },
   "_stats": {
     "systemId": "pf2e",
@@ -76,8 +73,7 @@
     "coreVersion": "12.329",
     "createdTime": 1675062551886,
     "modifiedTime": 1721825633150,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": "Item.5QgPHAdpsUHJmCkX",
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.dNpf1EDKJ6fgNL42",
     "duplicateSource": null
   },
   "folder": null,

--- a/src/packs/thaumaturge-effects/thaumaturge-recall-knowledge.json
+++ b/src/packs/thaumaturge-effects/thaumaturge-recall-knowledge.json
@@ -58,8 +58,7 @@
   "img": "modules/pf2e-thaum-vuln/assets/chosen-implement.webp",
   "folder": null,
   "ownership": {
-    "default": 0,
-    "UQu4pcNxGHCGDRdj": 3
+    "default": 0
   },
   "flags": {
     "core": {}
@@ -70,8 +69,7 @@
     "coreVersion": "12.329",
     "createdTime": 1693546206297,
     "modifiedTime": 1721825645253,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.WL60y9JEjNqS4p3H",
     "duplicateSource": null
   },
   "_id": "WL60y9JEjNqS4p3H",

--- a/src/packs/thaumaturge-effects/tome-adept-rk.json
+++ b/src/packs/thaumaturge-effects/tome-adept-rk.json
@@ -51,8 +51,7 @@
   "img": "modules/pf2e-thaum-vuln/assets/frontal-lobe.webp",
   "folder": "jOCeu91o3wpQtjdd",
   "ownership": {
-    "default": 2,
-    "JCSogeTR741olRmm": 3
+    "default": 2
   },
   "flags": {
     "core": {}
@@ -63,8 +62,7 @@
     "coreVersion": "12.329",
     "createdTime": 1709968089785,
     "modifiedTime": 1721825879705,
-    "lastModifiedBy": "tdy2eK4qal8oP4OZ",
-    "compendiumSource": null,
+    "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.kg1CwmxZfKx7xWF3",
     "duplicateSource": null
   },
   "_id": "kg1CwmxZfKx7xWF3",


### PR DESCRIPTION
This adds some code to the build packs to set things like compendiumSource to the correct value.  It needs to be right, or stuff breaks.

Then I updated the json files by extracting the packs after re-building them.