### PR TITLE
Fix for tome proficiency not applying to rolls

### DIFF
--- a/src/module/implements/implementBenefits/tome.js
+++ b/src/module/implements/implementBenefits/tome.js
@@ -182,7 +182,7 @@ class Tome extends Implement {
         path: "{item|flags.pf2e.rulesSelections.effectTomeFirstSkill}",
         value: 3,
         priority: 50,
-        phase: "afterDerived",
+        phase: "beforeDerived",
       },
       {
         key: "ActiveEffectLike",
@@ -204,7 +204,7 @@ class Tome extends Implement {
           ],
         },
         priority: 50,
-        phase: "afterDerived",
+        phase: "beforeDerived",
       },
       {
         key: "ActiveEffectLike",
@@ -212,7 +212,7 @@ class Tome extends Implement {
         predicate: ["paragon:tome"],
         path: "{item|flags.pf2e.rulesSelections.effectTomeFirstSkill}",
         value: 4,
-        phase: "afterDerived",
+        phase: "beforeDerived",
       },
       {
         key: "ActiveEffectLike",
@@ -220,7 +220,7 @@ class Tome extends Implement {
         predicate: ["paragon:tome"],
         path: "{item|flags.pf2e.rulesSelections.effectTomeSecondSkill}",
         value: 4,
-        phase: "afterDerived",
+        phase: "beforeDerived",
       }
     );
 


### PR DESCRIPTION
Adept and Paragon Tome daily skill proficiency is currently set to "afterDerived" phase, however this happens after the modifier scores are calculated, so it doesn't affect the modifier scores and  leads to a misleading situation:
![Screenshot_pf2_bad_phase](https://github.com/user-attachments/assets/0257a693-b1d1-4854-b000-fba42b7931c1)
This pull request changes the phase to "beforeDerived", so that the modifier score is correctly calculated.