### PR TITLE
Don't error out on token without actor in scene when rendering character sheet

### DIFF
--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -268,7 +268,8 @@ Hooks.on("renderCharacterSheetPF2e", (_sheet, html, character) => {
       if (
         canvas.scene.tokens.filter(
           (token) =>
-            token.actor.uuid === a.getFlag("pf2e-thaum-vuln", "primaryEVTarget")
+            token.actor?.uuid ===
+            a.getFlag("pf2e-thaum-vuln", "primaryEVTarget")
         ).length != 0
       ) {
         EVTargetSection.append(EVTargetBtn);


### PR DESCRIPTION
If there was a token in the scene with no actor the hook for rendering the thaum's character sheet would error out.