### PR TITLE
Move some renderChatMessage handlers to other hooks

### DIFF
--- a/src/module/utils/helpers.js
+++ b/src/module/utils/helpers.js
@@ -178,14 +178,15 @@ function hasFeat(actor, slug) {
 }
 
 function getEffectOnActor(actor, sourceId) {
-  return actor.itemTypes.effect.find((effect) => effect.sourceId === sourceId);
+  return actor?.itemTypes.effect.find((effect) => effect.sourceId === sourceId);
 }
 
 // Is the actor a thaumaturge, either class or archetype?
 function isThaumaturge(actor) {
   return (
-    actor.class?.slug === "thaumaturge" ||
-    actor.rollOptions.all["class:thaumaturge"]
+    actor &&
+    (actor.class?.slug === "thaumaturge" ||
+      actor.rollOptions.all["class:thaumaturge"])
   );
 }
 


### PR DESCRIPTION
These handlers were acting on old chat messages when scrolling back in the chat history as if they were current.

Also fixes a few bugs.

Use isThaumaturge() instead of checking translated class name.  Fixes an issue where dual-class thaum didn't update weakness.

The check for the EW save being used didn't take into account that the EW modifier will show up in the save context for saves where it wasn't used, but with enabled set to false.  This caused the EW save to get removed on the first save rolled, even if it wasn't against the EV target.

Move the update vulnerability and esoteric warden attack handlers to createChatMessage.  They only run on new messages this way.  They both have a different user take an action than the one who created the message, so need to run for all users on each chat message.

For the esoteric warden save handler, it's the same user who rolls the save as will update the EW effect, so it's done in preCreateChatMessage and only the rolling user will run the hook.

Get target of strike from message.target, instead of doing lookup from thaum module specific flag.

The esoteric warden check would iterate over every item of every target of every attack and save message.  Speed this up by doing the fast checks first.  I.e., don't look at the targets if the message isn't an attack.  Then just look at the effects on the attacker to see if they are an EV target of anyone.  And then see if thaum(s) that has them as EV target is in the message target list.