### PR TITLE
Add Domains to EV Macro

### DIFF
--- a/src/module/feats/exploit-vulnerability/exploitVulnerability.js
+++ b/src/module/feats/exploit-vulnerability/exploitVulnerability.js
@@ -116,8 +116,6 @@ async function exploitVuln() {
     );
   }
 
-  const rollOptions = sa.getRollOptions(["skill-check", skill.slug]);
-
   const outcomes = {
     criticalSuccess: game.i18n.localize(
       "pf2e-thaum-vuln.exploitVulnerability.degreeOfSuccess.criticalSuccess"
@@ -186,41 +184,16 @@ async function exploitVuln() {
     });
   }
 
-  const flavor = `${game.i18n.localize(
-    "pf2e-thaum-vuln.exploitVulnerability.name"
-  )}: ${skill.label}`;
-  const checkModifier = new game.pf2e.CheckModifier(flavor, skill);
   const traits = ["esoterica", "manipulate", "thaumaturge"];
-  const evRoll = await game.pf2e.Check.roll(
-    checkModifier,
-    {
-      actor: sa,
-      target: {
-        actor: t.actor,
-        token: t.document,
-      },
-      type: "skill-check",
-      options: rollOptions,
-      notes,
-      dc: { value: dc },
-      traits: traits,
-      flavor: `
-    <strong>${game.i18n.localize(
-      "pf2e-thaum-vuln.exploitVulnerability.frequency.label"
-    )}</strong> ${game.i18n.localize(
-        "pf2e-thaum-vuln.exploitVulnerability.frequency.text"
-      )}<br/>
-    <strong>${game.i18n.localize(
-      "pf2e-thaum-vuln.exploitVulnerability.requirements.label"
-    )}</strong> ${game.i18n.localize(
-        "pf2e-thaum-vuln.exploitVulnerability.requirements.text"
-      )}<br/>
-    <hr/>
-    <p>${game.i18n.localize("pf2e-thaum-vuln.exploitVulnerability.flavor")}</p>
-  `,
-    },
-    event
-  );
+  const opt = {
+    label: "Exploit Vulnerability: " + skill.label,
+    target: t.actor,
+    action: "exploit-vulnerability",
+    extraRollNotes: notes,
+    dc: dc,
+    traits: traits,
+  };
+  const evRoll = await skill.roll(opt);
 
   const rollDOS = evRoll?.degreeOfSuccess;
   //Apply effect based on Degrees of success


### PR DESCRIPTION
Changes from `Check.roll` to `skill.roll`, making the code a bit more brief and adds the Domains to the roll automatically.