### PR TITLE
Fix complex exceptions for Breached Defenses such as Magical Silver

### DIFF
--- a/src/module/feats/breachedDefenses.js
+++ b/src/module/feats/breachedDefenses.js
@@ -23,27 +23,85 @@ async function createBreachedDefenses(sa, eff, bypassable) {
     bypassable.exceptions[0] = "ghost-touch";
   }
 
-  const exception = (() => {
-    for (const exception of bypassable.exceptions) {
-      for (const types in ADJUSTMENT_TYPES) {
-        if (ADJUSTMENT_TYPES[types].data[exception]) {
-          return {
-            property: ADJUSTMENT_TYPES[types].propLabel,
-            exception: exception,
-          };
+  //Fixes silly exceptions like the Adamantine Golem's "vorpal-adamantine" - However,
+  //Adamantine Golem still doesn't work properly because Vorpal is a rune, and the
+  //exception isn't fully implemented it appears.
+  const splitExceptions = bypassable.exceptions.map((x) =>
+    typeof x === "string" ? x.split("-").flat() : x
+  );
+
+  //Complex exceptions (such as Magical Silver) are set up very differently from simple exceptions.
+  //The exception needs to be coerced a little to be in a usable state.
+  const predicate = new Array();
+  for (let exception of splitExceptions) {
+    if (exception.definition) {
+      for (const instance of exception.definition) {
+        if (typeof instance === "string") {
+          const isplit = instance.split(":");
+          predicate.push(isplit[isplit.length - 1]);
+        } else {
+          for (const subinstance of Object.values(instance).flat()) {
+            const ssplit = subinstance.split(":");
+            predicate.push(ssplit[ssplit.length - 1]);
+          }
         }
       }
     }
+  }
+
+  const bypassables = predicate.length != 0 ? predicate : splitExceptions;
+
+  const exception = (() => {
+    const exceptionObject = { property: {} };
+    for (const exception of bypassables) {
+      for (const types in ADJUSTMENT_TYPES) {
+        if (ADJUSTMENT_TYPES[types].data[exception]) {
+          if (
+            exceptionObject.property[ADJUSTMENT_TYPES[types].propLabel] ===
+            undefined
+          ) {
+            exceptionObject.property[ADJUSTMENT_TYPES[types].propLabel] = [];
+          }
+          exceptionObject.property[ADJUSTMENT_TYPES[types].propLabel].push(
+            exception
+          );
+        }
+      }
+    }
+    return exceptionObject;
   })();
+
   if (!exception)
     return ui.notifications.error(`Don't know how to bypass ${bypassable}`);
 
-  const bypassRule = eff.system.rules.find(
-    (rule) => rule.slug === "breached-defenses-bypass"
-  );
-  bypassRule.value = exception.exception;
-  bypassRule.property = exception.property;
-  await sa.setFlag("pf2e-thaum-vuln", "EVValue", exception.exception);
+  //We add all of the possible bypassable exceptions as rules. It shouldn't matter which applies
+  //as long as the resistance is bypassed.
+  for (const type in exception.property) {
+    for (const exc of exception.property[type]) {
+      const bypassRule = eff.system.rules.find(
+        (rule) => rule.slug === `breached-defenses-${type}-${exc}`
+      );
+      if (!bypassRule) {
+        eff.system.rules = [
+          ...eff.system.rules,
+          {
+            definition: [{ or: ["item:type:weapon", "item:trait:unarmed"] }],
+            key: "AdjustStrike",
+            mode: "add",
+            property: type,
+            value: exc,
+            slug: `breached-defenses-${type}-${exc}`,
+            predicate: ["target:mark:exploit-vulnerability"],
+          },
+        ];
+      } else {
+        bypassRule.value = exc;
+        bypassRule.property = type;
+      }
+    }
+  }
+
+  await sa.setFlag("pf2e-thaum-vuln", "EVValue", exception);
 
   return {
     exception: exception,

--- a/src/module/feats/exploit-vulnerability/dialog.js
+++ b/src/module/feats/exploit-vulnerability/dialog.js
@@ -54,9 +54,15 @@ async function createEVDialog(sa, t, rollDOS) {
       }
     }
     if (tRes.length != 0 && exceptionFlag > 0) {
+      //Complex exceptions (such as Magical Silver) are set up very differently from simple exceptions.
+      //The label needs to be read from a different location and localized.
+      const rawBypassables = BDGreatestBypassableResistance(t)?.exceptions.map(
+        (x) => (x.label ? game.i18n.localize(x.label) : x)
+      );
+
       gBD = game.i18n.format("pf2e-thaum-vuln.breachedDefenses.bypassLine", {
         type: BDGreatestBypassableResistance(t)?.type,
-        exception: BDGreatestBypassableResistance(t)?.exceptions,
+        exception: rawBypassables,
       });
       dgBtns = {
         ...dgBtns,
@@ -144,10 +150,11 @@ function stitchIWR(p, rollDOS) {
             "pf2e-thaum-vuln.exploitVulnerability.dialog.except"
           );
         for (const e of n.exceptions) {
-          if (e === n.exceptions[n.exceptions.length - 1]) {
-            s = s + `${e}`;
+          const bypassable = e.label ? game.i18n.localize(e.label) : e;
+          if (n.exceptions.length === 1) {
+            s = s + `${bypassable}`;
           } else {
-            s = s + `${e}, `;
+            s = s + `${bypassable}, `;
           }
         }
         s = s + "<br>";

--- a/src/packs/thaumaturge-effects/breached-defenses.json
+++ b/src/packs/thaumaturge-effects/breached-defenses.json
@@ -8,31 +8,14 @@
     },
     "rules": [
       {
-        "definition": [
-          {
-            "or": [
-              "item:type:weapon",
-              "item:trait:unarmed"
-            ]
-          }
-        ],
-        "key": "AdjustStrike",
-        "mode": "add",
-        "property": "materials",
-        "value": "adamantine",
-        "slug": "breached-defenses-bypass",
-        "predicate": [
-          "target:mark:exploit-vulnerability"
-        ]
-      },
-      {
         "key": "AdjustStrike",
         "mode": "add",
         "property": "weapon-traits",
         "value": "magical",
         "predicate": [
           "target:mark:exploit-vulnerability"
-        ]
+        ],
+        "slug": "breached-defenses-magical"
       },
       {
         "key": "TokenMark",
@@ -90,12 +73,13 @@
   },
   "_stats": {
     "systemId": "pf2e",
-    "systemVersion": "6.1.1",
-    "coreVersion": "12.329",
+    "systemVersion": "6.8.0",
+    "coreVersion": "12.331",
     "createdTime": 1675815751178,
-    "modifiedTime": 1721825748891,
+    "modifiedTime": 1734850236992,
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.FMw5IpJdA6eOgtv1",
-    "duplicateSource": null
+    "duplicateSource": null,
+    "lastModifiedBy": "o29bm85va79jJPjh"
   },
   "folder": null,
   "sort": 400000,


### PR DESCRIPTION
Changes some of the logic in breached defenses to compensate for complex resistance exceptions, such as the Vampire Count's physical resistance (except magical silver). 
Complex resistance exceptions are not set up the same way as simple resistance exceptions, so there's quite a bit more digging into the object to find what we need to add all of the proper rule elements to the Breached Defenses effect. This also fixes the dialog box's incorrect "except [object object]" lines that were produced for complex exceptions.
There is still an issue with the Adamantine Golem - it looks like the vorpal rune isn't part of the IWR calculation during a strike... which makes sense since runes are not fully implemented yet. Either way, this solution also handles that problem in the future (why is it ['vorpal-adamantine'] instead of ['vorpal', 'adamantine']????) when runes are implemented.