### PR TITLE
Support rerolls for EV check

### DIFF
--- a/src/module/feats/exploit-vulnerability/exploitVulnerability.js
+++ b/src/module/feats/exploit-vulnerability/exploitVulnerability.js
@@ -1,5 +1,8 @@
 import { deleteEVEffect } from "../../socket.js";
-import { OFF_GUARD_EFFECT_UUID } from "../../utils/index.js";
+import {
+  OFF_GUARD_EFFECT_UUID,
+  ESOTERIC_WARDEN_EFFECT_UUID,
+} from "../../utils/index.js";
 import {
   createEffectData,
   getActorEVEffect,
@@ -11,7 +14,7 @@ import { createPAOnActor } from "./helpers.js";
 async function exploitVuln() {
   //grab the selected token and the targeted token
   const a = canvas.tokens.controlled;
-  let ts = Array.from(game.user.targets);
+  const ts = Array.from(game.user.targets);
 
   //make sure we're only targeting one target and have the thaum selected
   if (a.length != 1 || ts.length != 1) {
@@ -23,7 +26,7 @@ async function exploitVuln() {
   }
 
   //set the first index in the array as the target and the first controlled token actor as selected actor
-  const t = Array.from(ts)[0];
+  const t = ts[0];
   const sa = a[0].actor;
 
   //check for exploit vulnerability on the actor
@@ -52,26 +55,6 @@ async function exploitVuln() {
     }
   }
 
-  //deletes Exploit Vulnerability effect if it already exists on the actor
-  const deleteEffectTargs = preDeleteEffect(canvas.tokens.placeables, sa);
-  if (deleteEffectTargs.length > 0) {
-    deleteEVEffect(deleteEffectTargs.flat());
-  }
-  for (let act of canvas.tokens.placeables) {
-    let EWEffect = act.actor?.items.find(
-      (item) =>
-        item.name ===
-        game.i18n.localize("pf2e-thaum-vuln.esotericWarden.effect.name")
-    );
-    if (
-      EWEffect &&
-      (act.actor === sa ||
-        act.actor.getFlag("pf2e-thaum-vuln", "EWSourceActor") === sa.uuid)
-    ) {
-      EWEffect.delete();
-    }
-  }
-
   // From https://gist.github.com/stwlam/01c2506e93c298b01ad83c182b245144 by somebody, Supe, and stwlam
   const skill =
     sa.skills["esoteric-lore"] ??
@@ -84,6 +67,8 @@ async function exploitVuln() {
       )
     );
   }
+
+  deleteEffects(sa);
 
   let notes = [];
   if (hasFeat(sa, "diverse-lore")) {
@@ -116,8 +101,15 @@ async function exploitVuln() {
     notes,
     event,
   });
-  const evRoll = result[0].roll;
 
+  applyEVResult(sa, t, result[0].roll);
+}
+
+// Apply the results of an EV roll to the thaum and target
+// @param {ActorPF2e} sa     The thaum.
+// @param {TokenPF2e} t      The target of the EV roll.
+// @param {CheckRoll} evRoll The result of the EV roll.
+async function applyEVResult(sa, t, evRoll) {
   const rollDOS = evRoll?.degreeOfSuccess;
   //Apply effect based on Degrees of success
   switch (rollDOS) {
@@ -164,6 +156,22 @@ function preDeleteEffect(a, sa = undefined) {
   return effects;
 }
 
+function deleteEffects(actor) {
+  //deletes Exploit Vulnerability effect if it already exists on the actor
+  const deleteEffectTargs = preDeleteEffect(canvas.tokens.placeables, actor);
+  if (deleteEffectTargs.length > 0) {
+    deleteEVEffect(deleteEffectTargs.flat());
+  }
+  // Delete all Esoteric Warden effects from this character
+  for (const t of canvas.tokens.placeables) {
+    t.actor.itemTypes.effect
+      .filter(
+        (e) => e.sourceId === ESOTERIC_WARDEN_EFFECT_UUID && e.origin == actor
+      )
+      .forEach((e) => e.delete());
+  }
+}
+
 Hooks.once("init", () => {
   const climb = game.pf2e.actions.get("climb");
   const SingleCheckAction = Object.getPrototypeOf(climb).constructor;
@@ -200,6 +208,25 @@ Hooks.once("init", () => {
   });
 
   game.pf2e.actions.set("exploit-vulnerability", ExploitVulnerability);
+});
+
+Hooks.on("preCreateChatMessage", async (msg) => {
+  if (
+    msg.isReroll &&
+    msg.isCheckRoll &&
+    msg.flags.pf2e.context.dc?.slug === "exploit-vulnerability"
+  ) {
+    deleteEffects(msg.actor);
+    const EWImmuneTargs = msg.actor.getFlag("pf2e-thaum-vuln", "EWImmuneTargs");
+    if (EWImmuneTargs?.includes(msg.target.actor.uuid)) {
+      await msg.actor.setFlag(
+        "pf2e-thaum-vuln",
+        "EWImmuneTargs",
+        EWImmuneTargs.filter((t) => t != msg.target.actor.uuid)
+      );
+    }
+    applyEVResult(msg.actor, msg.target.token, msg.rolls[0]);
+  }
 });
 
 export { exploitVuln, preDeleteEffect };

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -268,7 +268,6 @@ async function _socketSharedWarding(eff, a) {
         "EVTargetID",
         a.actor.getFlag("pf2e-thaum-vuln", "EVTargetID")
       );
-      token.actor.setFlag("pf2e-thaum-vuln", "EWSourceActor", a.actor.uuid);
     }
   }
 }


### PR DESCRIPTION
Uses the preCreateChatMessage hook to detect the roll result chat message when the new message is posted.  The message will have isReroll set and the check DC of "exploit-vulnerability" to identify it as an EV reroll.

Since preCreateChatMessage will only get called for the user who clicked the reroll, we know we can handle the action and don't need to worry about primaryUpdater or checking actor permissions.  We don't even need to check if they are a thaum, since this is reroll they must be in order to have make the original roll in the first place.

Refactor out the "delete old effects" and "create effect part" of the original function to be called on reroll.

Deleting the old EW effects can be simplified some to use effect.origin to determine if they are our EW effect or some another thaum.

Get rid of EWSourceActor flag

Nothing uses it anymore.  It's possible to tell what actor the EW effect on allies came from by looking at `effect.origin`.