### PR TITLE
Don't add roll options for tome skill selection

### DIFF
--- a/src/module/implements/implementBenefits/tome.js
+++ b/src/module/implements/implementBenefits/tome.js
@@ -139,7 +139,6 @@ class Tome extends Implement {
           "feature:tome",
         ],
         prompt: "First Skill Proficiency",
-        rollOption: "self:implement:tome:firstSkill",
       },
       {
         adjustName: true,
@@ -151,7 +150,6 @@ class Tome extends Implement {
           "feature:tome",
         ],
         prompt: "Second Skill Proficiency",
-        rollOption: "self:implement:tome:secondSkill",
       },
       {
         key: "ActiveEffectLike",


### PR DESCRIPTION
This ends up creating a roll option with a name like: self:implement:tome:firstSkill:system.skills.athletics.rank

It turns out having a "." in a roll option is a bad idea.  Eventually the foundry utility mergeObject will get called to merge roll options, and when it sees an object like:

`{"self:implement:tome:firstSkill:system.skills.athletics.rank": true}`

It thinks the property key with a "." is a stacked object path and will split it, interpreting it as trying to add in the object:

`{"self:implement:tome:firstSkill:system": { skills: { athletics: { rank: true } } } }`

These roll options are never used anywhere so it's easiest to just not have them.