### PR TITLE
Twin Weakness should only apply to the EV target

### DIFF
--- a/src/module/feats/exploit-vulnerability/helpers.js
+++ b/src/module/feats/exploit-vulnerability/helpers.js
@@ -63,7 +63,6 @@ async function createPAOnActor(actor, target, rollDOS, data) {
 
   await setEVFlags({
     actor: actor,
-    targets: evTargets,
     primary: target,
     mode: evMode,
   });
@@ -172,7 +171,6 @@ async function createMWOnActor(actor, target, rollDOS, data) {
 
   await setEVFlags({
     actor: actor,
-    targets: evTargets,
     primary: target,
     mode: evMode,
   });
@@ -216,7 +214,6 @@ async function createBDOnActor(actor, target, rollDOS, data) {
 
   await setEVFlags({
     actor: actor,
-    targets: evTargets,
     primary: target,
     mode: evMode,
   });
@@ -248,7 +245,6 @@ async function createGWOnActor(actor, target, data) {
 
   await setEVFlags({
     actor: actor,
-    targets: [target.actor.uuid],
     primary: target,
     mode: "glimpse-vulnerability",
   });
@@ -263,10 +259,9 @@ async function createGWOnActor(actor, target, data) {
  * @param {*} data
  */
 async function setEVFlags(data) {
-  const { actor, targets, primary, mode } = data;
+  const { actor, primary, mode } = data;
   await actor.setFlag("pf2e-thaum-vuln", "effectSource", actor.uuid);
   await actor.setFlag("pf2e-thaum-vuln", "activeEV", true);
-  await actor.setFlag("pf2e-thaum-vuln", "EVTargetID", targets);
   await actor.setFlag("pf2e-thaum-vuln", "EVMode", `${mode}`);
   await actor.setFlag("pf2e-thaum-vuln", "primaryEVTarget", primary.actor.uuid);
 }

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -187,7 +187,6 @@ Hooks.on("deleteItem", async (item) => {
     game.user === sa.primaryUpdater
   ) {
     await sa.setFlag("pf2e-thaum-vuln", "activeEV", false);
-    await sa.unsetFlag("pf2e-thaum-vuln", "EVTargetID");
     await sa.unsetFlag("pf2e-thaum-vuln", "EVMode");
     await sa.unsetFlag("pf2e-thaum-vuln", "EVValue");
     await sa.unsetFlag("pf2e-thaum-vuln", "primaryEVTarget");

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -263,11 +263,6 @@ async function _socketSharedWarding(eff, a) {
   for (let token of affectedTokens) {
     if (token != a._object) {
       await token.actor.createEmbeddedDocuments("Item", [eff]);
-      token.actor.setFlag(
-        "pf2e-thaum-vuln",
-        "EVTargetID",
-        a.actor.getFlag("pf2e-thaum-vuln", "EVTargetID")
-      );
     }
   }
 }


### PR DESCRIPTION
Sympathetic Vulnerabilities doesn't make the additional creatures that will take extra damage targets of Exploit Vulnerability.  So things like Intensify Vulnerability, Implement's Interruption, or Twin Weakness still only work on the primary EV target.

All the rest were like this, but Twin Weakness allowed the additional SV targets to be used.

After doing this, the flag EVTargetID is never used.  So the code to set it can all be deleted too.

Also use the callback of the attack roll to get the DoS and trigger the EXtra damage roll.  Rather than add and remove a hook and hope the next attack roll message is the right one.