### PR TITLE
Add buttons to apply tome adept RK bonus to other RK rolls

### DIFF
--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -273,7 +273,7 @@ async function _socketSharedWarding(eff, a) {
 }
 
 // GM Does the RK roll, this tells the user who did the roll what happened.
-function RKCallback(userId, saUuid, targUuid, roll) {
+export function RKCallback(userId, saUuid, targUuid, roll) {
   return socket.executeAsUser(
     _RKCallback,
     userId,


### PR DESCRIPTION
The tome adept function worked for the esoteric lore RK macro in the module, but not for rolls made using the workbench macro or the system action.

This adds buttons to those rolls so after deciding if the result is a success or failure the GM can click the button to apply the correct tome adept RK effect.