### PR TITLE
Add divine disharmony action

### DIFF
--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -132,6 +132,14 @@
       "bypassableLabel": "Highest Bypassable Resistance: ",
       "bypassedBy": "bypassed by"
     },
+    "divineDisharmony": {
+      "name": "Divine Disharmony",
+      "flavor":  "From your collection of religious trinkets, you pull out opposing divine objects—such as the religious symbols of two deities that are hated enemies—and combine them in a display that causes discordant clashes of divine energy that are especially distracting to the faithful. Roll your choice of a Deception or Intimidation check against the Will DC of a creature you can see within 60 feet, with the following results.  If the creature is particularly devoted to a deity, such as a cleric, celestial, monitor, fiend, or other creature with divine spells, you gain a +2 circumstance bonus to your skill check.  The GM might determine that a creature that despises all deities, such as an alghollthu, is unaffected.",
+      "degreeOfSuccess": {
+        "criticalSuccess": "<strong>Critical Success</strong> The creature is flat-footed to your attacks until the end of your next turn. @UUID[Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.1Qg5deHGd0ou1EWY]{Effect: Divine Disharmony (Critical Success)}",
+        "success": "<strong>Success</strong> The creature is flat-footed against your attacks until the end of your current turn. @UUID[Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.lrc7YZ0FrfbljICC]{Effect: Divine Disharmony}"
+      }
+    },
     "esotericWarden": {
       "name": "Esoteric Warden",
       "effect": {

--- a/src/module/feats/divineDisharmony.js
+++ b/src/module/feats/divineDisharmony.js
@@ -1,0 +1,89 @@
+// Create a new action for Divine Disharmony
+
+Hooks.once("init", () => {
+  const climb = game.pf2e.actions.get("climb");
+  const SingleCheckAction = Object.getPrototypeOf(climb).constructor;
+  const SingleCheckActionVariant = Object.getPrototypeOf(
+    game.pf2e.actions.get("climb").toActionVariant()
+  ).constructor;
+
+  class DivineDisharmonyActionVariant extends SingleCheckActionVariant {
+    get statistic() {
+      return ""; // Default to highest modifier, rather than 1st in list of allowed modifiers
+    }
+
+    checkContext(opts, data) {
+      if (!data.slug) {
+        // Get highest modifier if none was specified
+        const highest = super.statistic
+          .map((slug) => {
+            const statistic = opts.actor.getStatistic(slug);
+            const rollOptions = opts.buildContext({
+              actor: opts.actor,
+              rollOptions: [
+                ...data.rollOptions,
+                `action:divine-disharmony:${statistic.slug}`,
+              ],
+              target: opts.target,
+            }).rollOptions;
+            return new game.pf2e.StatisticModifier(
+              statistic.slug,
+              statistic.modifiers.concat(data.modifiers ?? []),
+              rollOptions
+            );
+          })
+          .reduce((highest, current) =>
+            current.totalModifier > highest.totalModifier ? current : highest
+          );
+        data.slug = highest.slug;
+      }
+
+      return super.checkContext(opts, {
+        ...data,
+        rollOptions: [
+          ...data.rollOptions,
+          `action:divine-disharmony:${data.slug}`,
+        ],
+      });
+    }
+  }
+
+  class DivineDisharmonyAction extends SingleCheckAction {
+    constructor() {
+      super({
+        cost: 1,
+        description: "pf2e-thaum-vuln.divineDisharmony.flavor",
+        name: "pf2e-thaum-vuln.divineDisharmony.name",
+        img: "systems/pf2e/icons/equipment/treasure/art-objects/major-art-object/solidified-moment-of-time.webp",
+        notes: [
+          {
+            outcome: ["criticalSuccess"],
+            text: "pf2e-thaum-vuln.divineDisharmony.degreeOfSuccess.criticalSuccess",
+          },
+          {
+            outcome: ["success"],
+            text: "pf2e-thaum-vuln.divineDisharmony.degreeOfSuccess.success",
+          },
+        ],
+        rollOptions: ["action:divine-disharmony"],
+        slug: "divine-disharmony",
+        difficultyClass: "will",
+        statistic: ["intimidation", "deception"],
+        traits: [
+          "divine",
+          "enchantment",
+          "esoterica",
+          "manipulate",
+          "thaumaturge",
+        ],
+      });
+    }
+
+    toActionVariant(data) {
+      return new DivineDisharmonyActionVariant(this, data);
+    }
+  }
+
+  const action = new DivineDisharmonyAction();
+  game.pf2e.actions.set(action.slug, action);
+});

--- a/src/module/feats/index.js
+++ b/src/module/feats/index.js
@@ -4,3 +4,4 @@ import "./exploit-vulnerability/exploitVulnerability.js";
 import "./shareWeakness.js";
 import "./sympatheticVulnerabilities.js";
 import "./twinWeakness.js";
+import "./divineDisharmony.js";

--- a/src/packs/mysurvives-thaumaturge-macros/divine-disharmony.json
+++ b/src/packs/mysurvives-thaumaturge-macros/divine-disharmony.json
@@ -1,0 +1,22 @@
+{
+  "name": "Divine Disharmony",
+  "type": "script",
+  "command": "const action = game.pf2e.actions.get(\"divine-disharmony\");\nif (!action) {\n  return ui.notifications.error(\"Action not preset. Thaumaturge module not enabled?\");\n}\naction.use({actor, event});",
+  "img": "systems/pf2e/icons/equipment/treasure/art-objects/major-art-object/solidified-moment-of-time.webp",
+  "scope": "global",
+  "folder": null,
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "coreVersion": "12.343",
+    "systemId": "pf2e",
+    "systemVersion": "6.12.4",
+    "createdTime": 1748982135677,
+    "modifiedTime": 1748982135740
+  },
+  "_id": "FszKU1VxKe0JsEjy",
+  "sort": 200000,
+  "_key": "!macros!FszKU1VxKe0JsEjy"
+}

--- a/src/packs/thaumaturge-effects/effect-divine-disharmony-critical-success.json
+++ b/src/packs/thaumaturge-effects/effect-divine-disharmony-critical-success.json
@@ -1,0 +1,66 @@
+{
+  "folder": null,
+  "name": "Effect: Divine Disharmony (Critical Success)",
+  "type": "effect",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>From your collection of religious trinkets, you pull out opposing divine objects—such as the religious symbols of two deities that are hated enemies—and combine them in a display that causes discordant clashes of divine energy that are especially distracting to the faithful.</p><p><strong>Critical Success</strong> The creature is flat-footed against your attacks until the end of your current turn.</p><p><strong>Success</strong> The creature is flat-footed to your attacks until the end of your next turn.</p>"
+    },
+    "rules": [
+      {
+        "key": "GrantItem",
+        "onDeleteActions": {
+          "grantee": "restrict"
+        },
+        "uuid": "Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg"
+      }
+    ],
+    "slug": "effect-divine-disharmony",
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": []
+    },
+    "publication": {
+      "title": "Pathfinder Dark Archive",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "duration": {
+      "value": 1,
+      "unit": "rounds",
+      "expiry": "turn-end",
+      "sustained": false
+    },
+    "tokenIcon": {
+      "show": true
+    },
+    "unidentified": false
+  },
+  "img": "systems/pf2e/icons/conditions/off-guard.webp",
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.343",
+    "systemId": "pf2e",
+    "systemVersion": "6.12.4",
+    "createdTime": 1748896091251,
+    "modifiedTime": 1748896091348
+  },
+  "_id": "1Qg5deHGd0ou1EWY",
+  "sort": 200000,
+  "_key": "!items!1Qg5deHGd0ou1EWY"
+}

--- a/src/packs/thaumaturge-effects/effect-divine-disharmony.json
+++ b/src/packs/thaumaturge-effects/effect-divine-disharmony.json
@@ -1,0 +1,66 @@
+{
+  "folder": null,
+  "name": "Effect: Divine Disharmony",
+  "type": "effect",
+  "effects": [],
+  "system": {
+    "description": {
+      "gm": "",
+      "value": "<p>From your collection of religious trinkets, you pull out opposing divine objects—such as the religious symbols of two deities that are hated enemies—and combine them in a display that causes discordant clashes of divine energy that are especially distracting to the faithful.</p><p><strong>Critical Success</strong> The creature is flat-footed against your attacks until the end of your current turn.</p><p><strong>Success</strong> The creature is flat-footed to your attacks until the end of your next turn.</p>"
+    },
+    "rules": [
+      {
+        "key": "GrantItem",
+        "onDeleteActions": {
+          "grantee": "restrict"
+        },
+        "uuid": "Compendium.pf2e.conditionitems.Item.AJh5ex99aV6VTggg"
+      }
+    ],
+    "slug": "effect-divine-disharmony",
+    "_migration": {
+      "version": 0.935,
+      "lastMigration": null
+    },
+    "traits": {
+      "otherTags": [],
+      "value": []
+    },
+    "publication": {
+      "title": "Pathfinder Dark Archive",
+      "authors": "",
+      "license": "OGL",
+      "remaster": false
+    },
+    "level": {
+      "value": 1
+    },
+    "duration": {
+      "value": 0,
+      "unit": "rounds",
+      "expiry": "turn-end",
+      "sustained": false
+    },
+    "tokenIcon": {
+      "show": true
+    },
+    "unidentified": false
+  },
+  "img": "systems/pf2e/icons/conditions/off-guard.webp",
+  "ownership": {
+    "default": 0
+  },
+  "flags": {},
+  "_stats": {
+    "compendiumSource": null,
+    "duplicateSource": null,
+    "coreVersion": "12.343",
+    "systemId": "pf2e",
+    "systemVersion": "6.12.4",
+    "createdTime": 1748896091251,
+    "modifiedTime": 1748896091348
+  },
+  "_id": "lrc7YZ0FrfbljICC",
+  "sort": 200000,
+  "_key": "!items!lrc7YZ0FrfbljICC"
+}


### PR DESCRIPTION
This adds the action into the list of system actions in game.pf2e.actions.  The action devices from the SingleCheckAction class, which does most of the work. There is some complexity to automatically pick the best skill from intimidation or deception to use.

There is a macro that calls the action.

There are two effects that provide of off-guard condition for the appropriate length of time based on degree of success.