### PR TITLE
Allow implement assignment to work with localized implements

### DIFF
--- a/src/module/implements/implement.js
+++ b/src/module/implements/implement.js
@@ -113,10 +113,8 @@ class Implement {
     if (implement) this.deleteEffectsOnItem();
 
     if (
-      game.settings.get(
-        "pf2e-thaum-vuln",
-        `moduleHandles-${this.slug}`
-      ) === false
+      game.settings.get("pf2e-thaum-vuln", `moduleHandles-${this.slug}`) ===
+      false
     )
       return;
 


### PR DESCRIPTION
In the current version, the function errors as it tries to use a localized item name in the setting name.