### PR TITLE
Only send regalia reminders if at least one actor is frightened

### DIFF
--- a/src/module/implements/implementBenefits/regalia.js
+++ b/src/module/implements/implementBenefits/regalia.js
@@ -205,7 +205,7 @@ Hooks.on("pf2e.endTurn", (combatant) => {
   });
 
   // Don't attempt to send whispers if there are no targets for the whispers
-  if (whisperList.length > 0) {
+  if (whisperList.length > 0 && frightenedActors.length > 0) {
     ChatMessage.create({
       user: game.user.id,
       whisper: whisperList,


### PR DESCRIPTION
Currently, this whisper list for the regalia always includes the GM, even if no one is frightened.

This reduces the incidence of whispers to when there is at least one frightened creature who is affected by the regalia.  This means the message will appear when it is more likely to have a real effect.