### PR TITLE
Use the new custom weakness in the system for Personal Antithesis

### DIFF
--- a/src/module/feats/exploit-vulnerability/helpers.js
+++ b/src/module/feats/exploit-vulnerability/helpers.js
@@ -57,7 +57,6 @@ async function createPAOnActor(actor, target, rollDOS, data) {
   const targEffect = await createEffectData(PERSONAL_ANTITHESIS_TARGET_UUID, {
     actor: actor.uuid,
   });
-  targEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
   targEffect.system.slug =
     targEffect.system.slug + "-" + game.pf2e.system.sluggify(actor.name);
 
@@ -67,7 +66,6 @@ async function createPAOnActor(actor, target, rollDOS, data) {
     mode: evMode,
   });
 
-  eff.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
   await createEffectOnTarget(actor, targEffect, evTargets);
 
   await actor.createEmbeddedDocuments("Item", [eff]);
@@ -137,11 +135,8 @@ async function createMWOnActor(actor, target, rollDOS, data) {
   const targEffect = await createEffectData(MORTAL_WEAKNESS_TARGET_UUID, {
     actor: actor.uuid,
   });
-  targEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
   targEffect.system.slug =
     targEffect.system.slug + "-" + game.pf2e.system.sluggify(actor.name);
-
-  eff.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
 
   if (traitTypes) {
     eff.system.rules.push({
@@ -206,11 +201,8 @@ async function createBDOnActor(actor, target, rollDOS, data) {
   const targEffect = await createEffectData(BREACHED_DEFENSES_TARGET_UUID, {
     actor: actor.uuid,
   });
-  targEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
   targEffect.system.slug =
     targEffect.system.slug + "-" + game.pf2e.system.sluggify(actor.name);
-
-  eff.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
 
   await setEVFlags({
     actor: actor,
@@ -237,11 +229,8 @@ async function createGWOnActor(actor, target, data) {
   const targEffect = await createEffectData(GLIMPSE_VULNERABILITY_TARGET_UUID, {
     actor: actor.uuid,
   });
-  targEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
   targEffect.system.slug =
     targEffect.system.slug + "-" + game.pf2e.system.sluggify(actor.name);
-
-  eff.flags["pf2e-thaum-vuln"] = { EffectOrigin: actor.uuid };
 
   await setEVFlags({
     actor: actor,

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -50,11 +50,7 @@ async function updateWeaknessType(message) {
   const strikeTarget = message.target?.actor;
   if (!strikeTarget || strikeTarget.primaryUpdater !== game.user) return;
 
-  const evOrigin = game.actors.get(
-    getExploitVulnerabilityEffect(message.actor).flags[
-      "pf2e-thaum-vuln"
-    ].EffectOrigin.split(".")[1]
-  );
+  const evOrigin = getExploitVulnerabilityEffect(message.actor).origin;
   const actorSlug = game.pf2e.system.sluggify(evOrigin.name);
   const evEffect = strikeTarget.itemTypes.effect.find(
     (e) =>

--- a/src/module/hooks.js
+++ b/src/module/hooks.js
@@ -53,9 +53,7 @@ async function updateWeaknessType(message) {
   const evOrigin = getExploitVulnerabilityEffect(message.actor).origin;
   const actorSlug = game.pf2e.system.sluggify(evOrigin.name);
   const evEffect = strikeTarget.itemTypes.effect.find(
-    (e) =>
-      e.slug === `personal-antithesis-target-${actorSlug}` ||
-      e.slug === `mortal-weakness-target-${actorSlug}`
+    (e) => e.slug === `mortal-weakness-target-${actorSlug}`
   );
   if (!evEffect) return;
   const strike = message._strike?.item.system;

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -164,22 +164,14 @@ async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
   // We can't use effect.sourceId because this isn't an EffectPF2e object
   // yet and doesn't have that getter.
   const eID = effect._stats.compendiumSource;
+  effect.system.level.value = a.level;
   if (effect.system.rules.length != 0) {
     if (eID === MORTAL_WEAKNESS_TARGET_UUID) {
       effect.system.rules[0].value = iwrData;
-      a.setFlag(
-        "pf2e-thaum-vuln",
-        "EVValue",
-        `${effect.system.rules[0].value}`
-      );
     } else if (eID === PERSONAL_ANTITHESIS_TARGET_UUID) {
-      effect.system.rules[0].value = Math.floor(a.level / 2) + 2;
-      a.setFlag(
-        "pf2e-thaum-vuln",
-        "EVValue",
-        `${effect.system.rules[0].value}`
-      );
+      iwrData = Math.floor(a.level / 2) + 2;
     }
+    a.setFlag("pf2e-thaum-vuln", "EVValue", iwrData);
   }
 
   effect.name = effect.name + ` (${a.name})`;

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -199,7 +199,6 @@ async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
       primaryEVTargetEffect.system.slug +=
         "-" + game.pf2e.system.sluggify(a.name);
       primaryEVTargetEffect.name += ": " + a.name;
-      primaryEVTargetEffect.flags["pf2e-thaum-vuln"] = { EffectOrigin: aID };
 
       let primaryEffect = Object.assign({}, effect);
       if (primaryEffect.flags.core.sourceId === MORTAL_WEAKNESS_TARGET_UUID) {

--- a/src/module/socket.js
+++ b/src/module/socket.js
@@ -161,15 +161,18 @@ async function _socketCreateEffectsOnActors(
 
 async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
   const a = await fromUuid(aID);
+  // We can't use effect.sourceId because this isn't an EffectPF2e object
+  // yet and doesn't have that getter.
+  const eID = effect._stats.compendiumSource;
   if (effect.system.rules.length != 0) {
-    if (effect.flags.core.sourceId === MORTAL_WEAKNESS_TARGET_UUID) {
+    if (eID === MORTAL_WEAKNESS_TARGET_UUID) {
       effect.system.rules[0].value = iwrData;
       a.setFlag(
         "pf2e-thaum-vuln",
         "EVValue",
         `${effect.system.rules[0].value}`
       );
-    } else if (effect.flags.core.sourceId === PERSONAL_ANTITHESIS_TARGET_UUID) {
+    } else if (eID === PERSONAL_ANTITHESIS_TARGET_UUID) {
       effect.system.rules[0].value = Math.floor(a.level / 2) + 2;
       a.setFlag(
         "pf2e-thaum-vuln",
@@ -187,9 +190,9 @@ async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
     }
 
     if (
-      (effect.flags.core.sourceId === MORTAL_WEAKNESS_TARGET_UUID ||
-        effect.flags.core.sourceId === PERSONAL_ANTITHESIS_TARGET_UUID ||
-        effect.flags.core.sourceId === BREACHED_DEFENSES_TARGET_UUID) &&
+      (eID === MORTAL_WEAKNESS_TARGET_UUID ||
+        eID === PERSONAL_ANTITHESIS_TARGET_UUID ||
+        eID === BREACHED_DEFENSES_TARGET_UUID) &&
       a.getFlag("pf2e-thaum-vuln", "primaryEVTarget") === targ
     ) {
       const primaryEVTargetEffect = await createEffectData(
@@ -201,12 +204,10 @@ async function _socketCreateEffectOnTarget(aID, effect, evTargets, iwrData) {
       primaryEVTargetEffect.name += ": " + a.name;
 
       let primaryEffect = Object.assign({}, effect);
-      if (primaryEffect.flags.core.sourceId === MORTAL_WEAKNESS_TARGET_UUID) {
+      if (eID === MORTAL_WEAKNESS_TARGET_UUID) {
         primaryEffect.img =
           "modules/pf2e-thaum-vuln/assets/mortal-weakness-primary.webp";
-      } else if (
-        primaryEffect.flags.core.sourceId === PERSONAL_ANTITHESIS_TARGET_UUID
-      ) {
+      } else if (eID === PERSONAL_ANTITHESIS_TARGET_UUID) {
         primaryEffect.img =
           "modules/pf2e-thaum-vuln/assets/personal-antithesis-primary.webp";
       } else {

--- a/src/module/utils/forceEV.js
+++ b/src/module/utils/forceEV.js
@@ -4,13 +4,10 @@ import {
 } from ".";
 import { EVEffectsSourceIDs } from "./index";
 import { deleteEVEffect } from "../socket";
+import { createEffectData } from "./helpers";
 
 //macro that allows GMs to apply the same exploit vulnerability on a target
 async function forceEVTarget() {
-  const m = await fromUuid(MORTAL_WEAKNESS_TARGET_UUID);
-  const p = await fromUuid(PERSONAL_ANTITHESIS_TARGET_UUID);
-  let eff;
-
   let a = canvas.tokens.controlled[0];
   const sa = a.actor;
   let tar = Array.from(game.user.targets);
@@ -21,19 +18,23 @@ async function forceEVTarget() {
       )
     );
   }
-  let evM = a.actor.getFlag("pf2e-thaum-vuln", "EVMode");
-  if (evM === "mortal-weakness") {
-    eff = m.toObject();
-  } else if (evM === "personal-antithesis") {
-    eff = p.toObject();
-  } else {
+
+  const effectUuids = {
+    "mortal-weakness": MORTAL_WEAKNESS_TARGET_UUID,
+    "personal-antithesis": PERSONAL_ANTITHESIS_TARGET_UUID,
+  };
+  const uuid = effectUuids[sa.getFlag("pf2e-thaum-vuln", "EVMode")];
+  if (!uuid) {
     return ui.notifications.warn(
       game.i18n.localize(
         "pf2e-thaum-vuln.notifications.warn.forceEV.eVNotActivated"
       )
     );
   }
-  eff.flags["pf2e-thaum-vuln"] = { EffectOrigin: sa.uuid };
+  const eff = await createEffectData(uuid, {
+    actor: sa,
+    token: a,
+  });
   eff.system.rules[0].value = a.actor.getFlag("pf2e-thaum-vuln", "EVValue");
   eff.name += " (" + a.actor.name + ")";
   for (let targ of tar) {

--- a/src/module/utils/helpers.js
+++ b/src/module/utils/helpers.js
@@ -101,7 +101,7 @@ function targetEVPrimaryTarget(a) {
 // module code bypasses that step.
 async function createEffectData(uuid, origin = null) {
   const effect = (await fromUuid(uuid)).toObject();
-  (effect.flags.core ??= {}).sourceId = uuid;
+  effect._stats.compendiumSource = uuid;
   if (origin !== null) {
     // If context is set, then all these properties are non-optional, but can be null
     effect.system.context = {

--- a/src/packs/thaumaturge-effects/personal-antithesis-target.json
+++ b/src/packs/thaumaturge-effects/personal-antithesis-target.json
@@ -9,11 +9,14 @@
     "rules": [
       {
         "key": "Weakness",
-        "type": "physical",
-        "value": 7,
-        "predicate": [
-          "origin:effect:exploit-personal-antithesis"
+        "type": "custom",
+        "value": "floor(@item.level/2)+2",
+        "definition": [
+          "action:strike",
+          "origin:signature:{item|origin.signature}"
         ],
+        "applyOnce": true,
+        "label": "Personal Antithesis ({item|origin.name})",
         "slug": "personal-antithesis-weapons"
       }
     ],
@@ -69,12 +72,13 @@
   },
   "_stats": {
     "systemId": "pf2e",
-    "systemVersion": "6.1.1",
-    "coreVersion": "12.329",
+    "systemVersion": "7.4.2",
+    "coreVersion": "13.346",
     "createdTime": 1675062551886,
-    "modifiedTime": 1721825633150,
+    "modifiedTime": 1756275970369,
     "compendiumSource": "Compendium.pf2e-thaum-vuln.thaumaturge-effects.Item.dNpf1EDKJ6fgNL42",
-    "duplicateSource": null
+    "duplicateSource": null,
+    "exportSource": null
   },
   "folder": null,
   "sort": 700000,


### PR DESCRIPTION
Now that they can be applyOnce weaknesses, it's possible to use it for PA.

There is still an effect on the target(s) of PA, but the weakness in that effect is a custom one, with a definition of strike damage from the thaum.

That effect (and the other effects) will have the effect's level set to the level of the thaum.  The value of the weakness can be set based on effect level. So we don't need to modify the effect for that.

The hook that looked for strikes against a thaum target can stop looking for targets with PA on them, since it doesn't need to patch the weaknesses type.

This should fix issues with the current system of watching for attack rolls and changing the weakness type to a damage that a damage roll (might) do.  It should also fix issues when spell damage, or non-Strike damage in general, could also trigger the PA weakness, if the damage type happened to match.

This doesn't affect MW, which is a bit more complex due to Share Weakness.