### PR TITLE
Fix issue with null sourceId and Sympathetic Vulnerabilities

### DIFF
--- a/src/module/feats/sympatheticVulnerabilities.js
+++ b/src/module/feats/sympatheticVulnerabilities.js
@@ -1,3 +1,8 @@
+import {
+  MORTAL_WEAKNESS_EFFECT_UUID,
+  PERSONAL_ANTITHESIS_EFFECT_UUID,
+} from "../utils";
+
 /**
  * Gets the targets for Sympathetic Vulnerabilities.
  *
@@ -10,7 +15,7 @@
 
 function getSVTargets(t, effect, gIWR) {
   let targs = new Array();
-  if (effect.name.includes("Exploit Mortal Weakness")) {
+  if (effect._stats.compendiumSource === MORTAL_WEAKNESS_EFFECT_UUID) {
     for (let token of canvas.tokens.objects.children) {
       if (
         token.actor?.attributes.weaknesses.some((w) => w.type === gIWR.type)
@@ -18,8 +23,10 @@ function getSVTargets(t, effect, gIWR) {
         targs.push(token.actor.uuid);
       }
     }
-  } else if (effect.name.includes("Exploit Personal Antithesis")) {
-    if (t.actor.traits.has("humanoid")) return [];
+  } else if (
+    effect._stats.compendiumSource === PERSONAL_ANTITHESIS_EFFECT_UUID
+  ) {
+    if (t.actor.traits.has("humanoid") || !t.actor.sourceId) return [];
     for (let token of canvas.tokens.objects.children) {
       if (token.actor?.sourceId === t.actor.sourceId) {
         targs.push(token.actor.uuid);


### PR DESCRIPTION
It's possible for an actor to have a null sourceId if it's an old actor.  I don't think the migrations handled it properly.

The SV code was treating all such old actors as being the exact same creature, as they all have a sourceId of `null`.

It's much better to treat them as all not the same.